### PR TITLE
chore: secrets에 추가된 KEY 추가

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -77,6 +77,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             NODE_ENV=production
+            NOTION_API_KEY=${{ secrets.NOTION_API_KEY }}
+            NOTION_PEOPLE_DATABASE_ID=${{ secrets.NOTION_PEOPLE_DATABASE_ID }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.VERSION }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?
- **GitHub Secrets**에 `NOTION API KEY`와 `DATABASE ID`를 추가했습니다.
---

## 📋 체크리스트

- [ ] 변경 사항이 정상적으로 동작하는지 확인했습니다.

---

## 💬 하고 싶은 말
- 백엔드의 경우 따로 **Secrets**에 `.env` 파일에 있는 환경변수를 추가하지 않아도 도커 파일 빌드가 잘 되었기 때문에 프론트도 마찬가지일 거라고 **착각**했습니다. 
- `Spring Boot`는 빌드 산출물이 환경변수랑 무관하고, 실제 애플리케이션이 실행될 때(런타임)에 환경변수를 주입받아 사용합니다.
- 반면 Next.js는 지금 pre-rendering 방식이 SSG기 때문에 빌드 시점에 환경변수가 필요해서 ECS의 task definition을 다운로드 받기 전에 환경변수를 사용할 수 있게 해줄 필요가 있습니다.
  - secrets 사용 

