### PR TITLE
[feature] post 페이지 구현

### DIFF
--- a/apps/teampage/next.config.mjs
+++ b/apps/teampage/next.config.mjs
@@ -1,37 +1,44 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone",
+  output: 'standalone',
   webpack: (config, { dev, isServer }) => {
     if (dev && !isServer) {
-      config.devtool = "eval-source-map";
+      config.devtool = 'eval-source-map';
     }
     return config;
   },
   images: {
     remotePatterns: [
+      // TODO: mock 이미지를 위한 임시 추가
       {
-        protocol: "https",
-        hostname: "prod-files-secure.s3.us-west-2.amazonaws.com",
-        port: "",
-        pathname: "/**",
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+        port: '',
+        pathname: '/**',
       },
       {
-        protocol: "https",
-        hostname: "*.amazonaws.com",
-        port: "",
-        pathname: "/**",
+        protocol: 'https',
+        hostname: 'prod-files-secure.s3.us-west-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
       },
       {
-        protocol: "https",
-        hostname: "www.notion.so",
-        port: "",
-        pathname: "/**",
+        protocol: 'https',
+        hostname: '*.amazonaws.com',
+        port: '',
+        pathname: '/**',
       },
       {
-        protocol: "https",
-        hostname: "notion.so",
-        port: "",
-        pathname: "/**",
+        protocol: 'https',
+        hostname: 'www.notion.so',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'notion.so',
+        port: '',
+        pathname: '/**',
       },
     ],
   },

--- a/apps/teampage/package.json
+++ b/apps/teampage/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@notion-render/client": "^0.0.2",
     "@notionhq/client": "^4.0.2",
+    "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "catalog:",
     "@toast-ui/react-editor": "^3.2.3",
     "jotai": "^2.13.0",
@@ -19,15 +20,16 @@
     "next-auth": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-markdown": "^10.1.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@uoslife/api": "workspace:*",
     "@uoslife/eslint-config": "workspace:*",
     "@uoslife/typescript-config": "workspace:*",
-    "@uoslife/api": "workspace:*",
     "eslint": "^8",
     "eslint-config-next": "14.2.31",
     "postcss": "^8",

--- a/apps/teampage/package.json
+++ b/apps/teampage/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^18",
     "@uoslife/eslint-config": "workspace:*",
     "@uoslife/typescript-config": "workspace:*",
+    "@uoslife/api": "workspace:*",
     "eslint": "^8",
     "eslint-config-next": "14.2.31",
     "postcss": "^8",

--- a/apps/teampage/src/app/career/[id]/page.tsx
+++ b/apps/teampage/src/app/career/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { Post } from '@/widgets/post/Post';
+
+export default function TechPostPage({ params }: { params: { id: string } }) {
+  return <Post id={params.id} />;
+}

--- a/apps/teampage/src/app/moments/[id]/page.tsx
+++ b/apps/teampage/src/app/moments/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { Post } from '@/widgets/post/Post';
+
+export default function TechPostPage({ params }: { params: { id: string } }) {
+  return <Post id={params.id} />;
+}

--- a/apps/teampage/src/features/notion/NotionSchema.ts
+++ b/apps/teampage/src/features/notion/NotionSchema.ts
@@ -54,9 +54,9 @@ export const NotionPagePropertiesSchema = z.object({
   major: NotionRichTextPropertySchema,
   image_profile: OptionalNotionFilesPropertySchema,
   summary: OptionalNotionRichTextPropertySchema,
-  github: OptionalNotionUrlPropertySchema,
-  blog: OptionalNotionUrlPropertySchema,
-  linkedin: OptionalNotionUrlPropertySchema,
+  link_github: OptionalNotionUrlPropertySchema,
+  link_others: OptionalNotionUrlPropertySchema,
+  link_linkedin: OptionalNotionUrlPropertySchema,
 });
 
 export const NotionPageSchema = z.object({

--- a/apps/teampage/src/features/notion/NotionType.ts
+++ b/apps/teampage/src/features/notion/NotionType.ts
@@ -28,7 +28,7 @@ export type PeopleData = {
   major: string;
   image_profile?: string;
   summary?: string;
-  blog?: string;
-  github?: string;
-  linkedin?: string;
+  link_others?: string;
+  link_github?: string;
+  link_linkedin?: string;
 };

--- a/apps/teampage/src/features/notion/NotionUtil.ts
+++ b/apps/teampage/src/features/notion/NotionUtil.ts
@@ -88,9 +88,9 @@ export class NotionUtil {
       major: NotionUtil.extractMajor(properties.major),
       image_profile: NotionUtil.extractImageProfile(properties.image_profile),
       summary: NotionUtil.extractSummary(properties.summary),
-      blog: NotionUtil.extractLink(properties.blog),
-      github: NotionUtil.extractLink(properties.github),
-      linkedin: NotionUtil.extractLink(properties.linkedin),
+      link_others: NotionUtil.extractLink(properties.link_others),
+      link_github: NotionUtil.extractLink(properties.link_github),
+      link_linkedin: NotionUtil.extractLink(properties.link_linkedin),
     };
   };
 }

--- a/apps/teampage/src/features/people/PeopleCard.tsx
+++ b/apps/teampage/src/features/people/PeopleCard.tsx
@@ -10,9 +10,9 @@ type Person = {
   career?: string;
   summary?: string;
   image_profile?: string;
-  blog?: string;
-  github?: string;
-  linkedin?: string;
+  link_others?: string;
+  link_github?: string;
+  link_linkedin?: string;
 };
 
 interface PeopleCardProps {
@@ -97,10 +97,10 @@ export default function PeopleCard({ person }: PeopleCardProps) {
             </div>
           )}
           <div className="flex items-center gap-0.5 ml-auto">
-            {person.blog && (
+            {person.link_others && (
               <button
                 className="w-11 h-11 flex items-center justify-center text-gray-600 hover:text-[#0F6EFB] transition-colors"
-                onClick={() => window.open(person.blog, '_blank')}
+                onClick={() => window.open(person.link_others, '_blank')}
               >
                 <div className="flex items-center justify-center w-11 h-11 rounded-full  overflow-hidden hover:bg-gray-200">
                   <Image
@@ -112,10 +112,10 @@ export default function PeopleCard({ person }: PeopleCardProps) {
                 </div>
               </button>
             )}
-            {person.github && (
+            {person.link_github && (
               <button
                 className="w-11 h-11 flex items-center justify-center text-gray-600 hover:text-[#0F6EFB] transition-colors"
-                onClick={() => window.open(person.github, '_blank')}
+                onClick={() => window.open(person.link_github, '_blank')}
               >
                 <div className="flex items-center justify-center w-11 h-11 rounded-full  overflow-hidden hover:bg-gray-200">
                   <Image
@@ -127,10 +127,10 @@ export default function PeopleCard({ person }: PeopleCardProps) {
                 </div>
               </button>
             )}
-            {person.linkedin && (
+            {person.link_linkedin && (
               <button
                 className="w-11 h-11 flex items-center justify-center text-gray-600 hover:text-[#0F6EFB] transition-colors"
-                onClick={() => window.open(person.linkedin, '_blank')}
+                onClick={() => window.open(person.link_linkedin, '_blank')}
               >
                 <div className="flex items-center justify-center w-11 h-11 rounded-full  overflow-hidden hover:bg-gray-200">
                   <Image

--- a/apps/teampage/src/features/post/PostFooter.tsx
+++ b/apps/teampage/src/features/post/PostFooter.tsx
@@ -1,0 +1,115 @@
+import { Text } from '@/shared/component/Text';
+import { CommentResponse } from '@uoslife/api';
+
+type PostFooterProps = {
+  likeCount: number;
+  comments: CommentResponse[];
+};
+
+export const PostFooter = ({ likeCount, comments }: PostFooterProps) => {
+  return (
+    <>
+      <div className="flex gap-8 items-center">
+        <button className="border border-grey-100 border-solid flex gap-2 items-center px-5 py-3 rounded-[40px]">
+          <div className="w-6 h-6 flex items-center justify-center">
+            <svg className="w-5 h-[18px]" viewBox="0 0 20 18" fill="none">
+              <path
+                d="M10 17.5L8.55 16.2C3.4 11.6 0 8.5 0 4.75C0 2.1 2.1 0 4.75 0C6.25 0 7.7 0.7 8.55 1.8C9.4 0.7 10.85 0 12.25 0C14.9 0 17 2.1 17 4.75C17 8.5 13.6 11.6 8.45 16.2L10 17.5Z"
+                fill="#E9E9EE"
+              />
+            </svg>
+          </div>
+          <Text variant="body-18-m" color="grey-700">
+            좋아요
+          </Text>
+          <Text variant="title-24-b" color="grey-700">
+            {likeCount}
+          </Text>
+        </button>
+
+        <div className="flex gap-2 items-center">
+          <div className="w-6 h-6 flex items-center justify-center">
+            <svg className="w-[18px] h-5" viewBox="0 0 18 20" fill="none">
+              <path
+                d="M15 0H3C1.35 0 0 1.35 0 3V14C0 15.65 1.35 17 3 17H15L18 20V3C18 1.35 16.65 0 15 0Z"
+                fill="#44444C"
+              />
+            </svg>
+          </div>
+          <Text variant="body-18-m" color="grey-800">
+            공유하기
+          </Text>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-9 items-start justify-start w-full">
+        <div className="flex flex-col gap-4 items-start justify-start w-[880px]">
+          <Text variant="body-16-m" color="grey-900">
+            댓글 {comments.length}개
+          </Text>
+          <div className="flex flex-col gap-4 items-end justify-start w-full">
+            <div className="bg-grey-50 flex items-center justify-start p-5 rounded-[20px] w-full">
+              <Text variant="body-18-m" color="grey-500">
+                허위사실, 욕설, 사칭 등의 댓글은 통보없이 삭제될 수 있습니다.
+              </Text>
+            </div>
+            <button className="bg-grey-400 flex items-center justify-center h-12 px-5 py-1 rounded-[12px]">
+              <Text variant="body-20-m" color="white">
+                댓글 남기기
+              </Text>
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4 items-start justify-start w-full">
+          <div className="flex flex-col gap-5 items-start justify-start w-full">
+            <div className="bg-grey-50 flex flex-col gap-3 items-start justify-start px-8 py-7 rounded-[20px] w-[880px]">
+              <div className="flex items-center justify-between w-full">
+                <div className="flex gap-3 items-center">
+                  <div className="flex gap-2 items-center">
+                    <div className="w-7 h-7 bg-grey-300 rounded-full" />
+                    <Text variant="body-18-b" color="grey-900">
+                      작성자
+                    </Text>
+                  </div>
+                  <Text variant="body-16-m" color="grey-500">
+                    2025년 8월 17일
+                  </Text>
+                </div>
+                <div className="flex gap-3 items-center">
+                  <Text variant="body-14-m" color="grey-500">
+                    수정
+                  </Text>
+                  <div className="bg-grey-200 h-2 rounded w-px" />
+                  <Text variant="body-14-m" color="grey-500">
+                    삭제
+                  </Text>
+                </div>
+              </div>
+              <Text variant="body-18-m" color="grey-900">
+                댓글
+              </Text>
+            </div>
+
+            <div className="bg-grey-50 flex flex-col gap-3 items-start justify-start px-8 py-7 rounded-[20px] w-[880px]">
+              <div className="flex gap-3 items-center">
+                <div className="flex gap-2 items-center">
+                  <div className="w-7 h-7 bg-grey-300 rounded-full" />
+                  <Text variant="body-18-b" color="grey-900">
+                    작성자
+                  </Text>
+                </div>
+                <Text variant="body-16-m" color="grey-500">
+                  2025년 8월 17일
+                </Text>
+              </div>
+              <Text variant="body-18-m" color="grey-900">
+                댓글
+              </Text>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/apps/teampage/src/features/post/PostHeader.tsx
+++ b/apps/teampage/src/features/post/PostHeader.tsx
@@ -1,0 +1,77 @@
+import { Tag } from '@/shared/component/Tag';
+import { Text } from '@/shared/component/Text';
+
+export type PostType = 'tech' | 'career' | 'moments';
+
+type BasePostHeaderProps = {
+  type: PostType;
+  title: string;
+  authorName: string;
+  createdAt: string;
+};
+
+type TechPostHeaderProps = BasePostHeaderProps & {
+  category: string;
+  viewCount: number;
+};
+
+type CareerPostHeaderProps = BasePostHeaderProps & {
+  category: string;
+  viewCount: number;
+};
+
+interface PostHeaderProps extends TechPostHeaderProps, CareerPostHeaderProps {}
+
+export const PostHeader = ({
+  type,
+  title,
+  category,
+  authorName,
+  createdAt,
+  viewCount,
+}: PostHeaderProps) => {
+  return (
+    <div className="flex flex-col gap-7 items-start justify-start w-full">
+      <div className="flex flex-col gap-5 items-start justify-start w-full">
+        <Text variant="title-48-b" color="grey-900" className="w-full" as="h1">
+          {title}
+        </Text>
+
+        {category && <Tag color="white">{category}</Tag>}
+      </div>
+
+      <div className="flex items-start justify-between w-full">
+        <div className="flex gap-3 items-center">
+          <Text variant="body-18-m" color="grey-500">
+            {authorName}
+          </Text>
+          <div className="bg-grey-400 h-2.5 w-px" />
+          <Text variant="body-18-m" color="grey-500">
+            {new Date(createdAt).toLocaleDateString('ko-KR')}
+          </Text>
+          {type === 'tech' ||
+            (type === 'career' && (
+              <>
+                <div className="bg-grey-400 h-2.5 w-px" />
+                <Text variant="body-18-m" color="grey-500">
+                  조회수 {viewCount.toLocaleString()}
+                </Text>
+              </>
+            ))}
+        </div>
+
+        <div className="flex gap-2 items-center">
+          <Text variant="body-14-m" color="grey-500">
+            수정
+          </Text>
+          <div className="bg-grey-100 h-2.5 rounded w-px" />
+          <Text variant="body-14-m" color="grey-500">
+            삭제
+          </Text>
+        </div>
+      </div>
+
+      <div className="bg-grey-100 h-px w-full" />
+    </div>
+  );
+};

--- a/apps/teampage/src/features/post/PostSection.tsx
+++ b/apps/teampage/src/features/post/PostSection.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ArticleDetailResponse } from '@uoslife/api';
+import { Markdown } from '@/shared/component/markdown/Markdown';
+import { PostHeader, PostType } from './PostHeader';
+import { PostFooter } from './PostFooter';
+
+export function PostSection({
+  type,
+  post,
+}: {
+  type: PostType;
+  post: ArticleDetailResponse;
+}) {
+  return (
+    <div className="flex flex-col gap-[100px] items-center justify-start w-[880px] mx-auto mt-[140px] mb-[140px]">
+      <div className="flex flex-col gap-[60px] items-start justify-start w-full">
+        <PostHeader
+          type={type}
+          title={post.title}
+          category={post.category || ''}
+          authorName={post.authorName}
+          createdAt={post.createdAt}
+          viewCount={post.viewCount}
+        />
+
+        <div className="flex flex-col gap-[60px] items-start justify-start w-full">
+          {post.thumbnailUrl && (
+            <div
+              className="h-[400px] rounded-2xl w-full bg-center bg-cover bg-no-repeat"
+              style={{ backgroundImage: `url('${post.thumbnailUrl}')` }}
+            />
+          )}
+
+          <div className="w-full">
+            <Markdown content={post.content || ''} />
+          </div>
+        </div>
+      </div>
+
+      <PostFooter likeCount={post.likeCount} comments={post.comments} />
+    </div>
+  );
+}

--- a/apps/teampage/src/page/career-page/CareerMainSection.tsx
+++ b/apps/teampage/src/page/career-page/CareerMainSection.tsx
@@ -116,7 +116,11 @@ function ArticleList() {
     <div className="grid grid-cols-1 gap-y-10 max-w-pc w-full">
       {/* TODO: Change To Real Data */}
       {Array.from({ length: 5 }).map((_, index) => (
-        <Card.B key={index} content={DUMMY_CONTENT} />
+        <Card.B
+          key={index}
+          content={DUMMY_CONTENT}
+          link={`/career/${index}?type=career`}
+        />
       ))}
     </div>
   );

--- a/apps/teampage/src/page/moments-page/MomentsMainSection.tsx
+++ b/apps/teampage/src/page/moments-page/MomentsMainSection.tsx
@@ -85,7 +85,11 @@ function ArticleList() {
     <div className="grid grid-cols-2 gap-x-4 gap-y-20 max-w-pc w-full">
       {/* TODO: Change To Real Data */}
       {Array.from({ length: 5 }).map((_, index) => (
-        <Card.A key={index} content={DUMMY_CONTENT} />
+        <Card.A
+          key={index}
+          content={DUMMY_CONTENT}
+          link={`/moments/${index}?type=moments`}
+        />
       ))}
     </div>
   );

--- a/apps/teampage/src/page/tech-page/TechMainSection.tsx
+++ b/apps/teampage/src/page/tech-page/TechMainSection.tsx
@@ -116,7 +116,11 @@ function ArticleList() {
     <div className="grid grid-cols-1 gap-y-10 max-w-pc w-full">
       {/* TODO: Change To Real Data */}
       {Array.from({ length: 5 }).map((_, index) => (
-        <Card.B key={index} content={DUMMY_CONTENT} />
+        <Card.B
+          key={index}
+          content={DUMMY_CONTENT}
+          link={`/tech/${index}?type=tech`}
+        />
       ))}
     </div>
   );

--- a/apps/teampage/src/shared/component/card/CardA.tsx
+++ b/apps/teampage/src/shared/component/card/CardA.tsx
@@ -7,8 +7,9 @@ import { Divider } from '../Divider';
 import { Tag } from '../Tag';
 import { Text } from '../Text';
 import type { CardProps } from './types';
+import Link from 'next/link';
 
-export function CardA({ content, className }: CardProps) {
+export function CardA({ content, className, link }: CardProps) {
   const {
     authorName,
     title,
@@ -21,67 +22,77 @@ export function CardA({ content, className }: CardProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <motion.div
-      whileHover={{ translateY: -5 }}
-      whileTap={{ scale: 0.99 }}
-      onHoverStart={() => setIsHovered(true)}
-      onHoverEnd={() => setIsHovered(false)}
-      className={`relative flex flex-col rounded-3xl max-w-screen-lg w-full cursor-pointer ${className || ''}`}
-    >
-      <div className="h-[324px] flex">
-        <Image
-          src={thumbnailUrl}
-          alt={title}
-          width={768}
-          height={324}
-          className="object-cover rounded-t-3xl"
-        />
-      </div>
-      {category && (
-        <Tag color={'blur'} className="absolute top-5 left-5 opacity-80">
-          {category}
-        </Tag>
-      )}
-      <div className="bg-grey-50 box-border flex flex-col rounded-b-3xl h-[240px] p-8 items-start justify-between w-full">
-        <div className="flex flex-col gap-2 w-full">
-          <Text
-            variant="title-28-b"
-            color={isHovered ? 'primary-gradiant' : 'grey-900'}
-            className="line-clamp-2 text-ellipsis text-grey-900 w-full"
-          >
-            {title}
-          </Text>
-          <Text variant="body-18-m" color="grey-700" className="w-full">
-            {summary}
-          </Text>
-        </div>
-        <div className="flex gap-3 items-center justify-start relative">
-          <Text variant="body-16-b" color="grey-700" className="whitespace-pre">
-            {authorName}
-          </Text>
-          <Divider
-            orientation="vertical"
-            color="bg-grey-200"
-            className="h-3 w-px"
+    <Link href={link}>
+      <motion.div
+        whileHover={{ translateY: -5 }}
+        whileTap={{ scale: 0.99 }}
+        onHoverStart={() => setIsHovered(true)}
+        onHoverEnd={() => setIsHovered(false)}
+        className={`relative flex flex-col rounded-3xl max-w-screen-lg w-full cursor-pointer ${className || ''}`}
+      >
+        <div className="h-[324px] flex">
+          <Image
+            src={thumbnailUrl}
+            alt={title}
+            width={768}
+            height={324}
+            className="object-cover rounded-t-3xl"
           />
-          <Text variant="body-16-m" color="grey-600" className="whitespace-pre">
-            {new Date(createdAt).toLocaleDateString('ko-KR', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </Text>
-          {viewCount && (
+        </div>
+        {category && (
+          <Tag color={'blur'} className="absolute top-5 left-5 opacity-80">
+            {category}
+          </Tag>
+        )}
+        <div className="bg-grey-50 box-border flex flex-col rounded-b-3xl h-[240px] p-8 items-start justify-between w-full">
+          <div className="flex flex-col gap-2 w-full">
+            <Text
+              variant="title-28-b"
+              color={isHovered ? 'primary-gradiant' : 'grey-900'}
+              className="line-clamp-2 text-ellipsis text-grey-900 w-full"
+            >
+              {title}
+            </Text>
+            <Text variant="body-18-m" color="grey-700" className="w-full">
+              {summary}
+            </Text>
+          </div>
+          <div className="flex gap-3 items-center justify-start relative">
+            <Text
+              variant="body-16-b"
+              color="grey-700"
+              className="whitespace-pre"
+            >
+              {authorName}
+            </Text>
+            <Divider
+              orientation="vertical"
+              color="bg-grey-200"
+              className="h-3 w-px"
+            />
             <Text
               variant="body-16-m"
               color="grey-600"
               className="whitespace-pre"
             >
-              조회수 {viewCount.toLocaleString()}
+              {new Date(createdAt).toLocaleDateString('ko-KR', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
             </Text>
-          )}
+            {viewCount && (
+              <Text
+                variant="body-16-m"
+                color="grey-600"
+                className="whitespace-pre"
+              >
+                조회수 {viewCount.toLocaleString()}
+              </Text>
+            )}
+          </div>
         </div>
-      </div>
-    </motion.div>
+      </motion.div>
+    </Link>
   );
 }

--- a/apps/teampage/src/shared/component/card/CardB.tsx
+++ b/apps/teampage/src/shared/component/card/CardB.tsx
@@ -7,8 +7,9 @@ import { Divider } from '../Divider';
 import { Tag } from '../Tag';
 import { Text } from '../Text';
 import type { CardProps } from './types';
+import Link from 'next/link';
 
-export function CardB({ content, className }: CardProps) {
+export function CardB({ content, className, link }: CardProps) {
   const {
     title,
     summary,
@@ -21,74 +22,84 @@ export function CardB({ content, className }: CardProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <motion.div
-      whileHover={{ translateY: -5 }}
-      whileTap={{ scale: 0.99 }}
-      onHoverStart={() => setIsHovered(true)}
-      onHoverEnd={() => setIsHovered(false)}
-      className={`bg-grey-50 flex gap-10 items-start justify-start p-6 rounded-[24px] w-full cursor-pointer ${className || ''}`}
-    >
-      <div className="flex flex-col gap-6 flex-grow">
-        <div className="flex flex-col gap-3 w-full">
-          {category && (
-            <Tag color="white" className="self-start">
-              {category}
-            </Tag>
-          )}
-          <div className="flex flex-col gap-2 w-full">
+    <Link href={link}>
+      <motion.div
+        whileHover={{ translateY: -5 }}
+        whileTap={{ scale: 0.99 }}
+        onHoverStart={() => setIsHovered(true)}
+        onHoverEnd={() => setIsHovered(false)}
+        className={`bg-grey-50 flex gap-10 items-start justify-start p-6 rounded-[24px] w-full cursor-pointer ${className || ''}`}
+      >
+        <div className="flex flex-col gap-6 flex-grow">
+          <div className="flex flex-col gap-3 w-full">
+            {category && (
+              <Tag color="white" className="self-start">
+                {category}
+              </Tag>
+            )}
+            <div className="flex flex-col gap-2 w-full">
+              <Text
+                variant="title-28-b"
+                color={isHovered ? 'primary-gradiant' : 'grey-900'}
+                className={`text-grey-900 w-full `}
+              >
+                {title}
+              </Text>
+              <Text variant="body-18-m" color="grey-700" className="w-full">
+                {summary}
+              </Text>
+            </div>
+          </div>
+          <div className="flex gap-2 items-center">
             <Text
-              variant="title-28-b"
-              color={isHovered ? 'primary-gradiant' : 'grey-900'}
-              className={`text-grey-900 w-full `}
+              variant="body-16-b"
+              color="grey-700"
+              className="whitespace-pre"
             >
-              {title}
+              {authorName}
             </Text>
-            <Text variant="body-18-m" color="grey-700" className="w-full">
-              {summary}
+            <Divider
+              orientation="vertical"
+              thickness="px"
+              color="bg-grey-200"
+              className="h-2.5"
+            />
+            <Text
+              variant="body-16-m"
+              color="grey-600"
+              className="whitespace-pre"
+            >
+              {new Date(createdAt).toLocaleDateString('ko-KR', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </Text>
+            <Divider
+              orientation="vertical"
+              thickness="px"
+              color="bg-grey-200"
+              className="h-2.5"
+            />
+            <Text
+              variant="body-16-m"
+              color="grey-600"
+              className="whitespace-pre text-right"
+            >
+              조회수 {viewCount.toLocaleString()}
             </Text>
           </div>
         </div>
-        <div className="flex gap-2 items-center">
-          <Text variant="body-16-b" color="grey-700" className="whitespace-pre">
-            {authorName}
-          </Text>
-          <Divider
-            orientation="vertical"
-            thickness="px"
-            color="bg-grey-200"
-            className="h-2.5"
+        <div className="h-36 w-60 rounded-[12px] overflow-hidden flex-shrink-0">
+          <Image
+            src={thumbnailUrl}
+            alt={title}
+            width={240}
+            height={144}
+            className="object-cover w-full h-full"
           />
-          <Text variant="body-16-m" color="grey-600" className="whitespace-pre">
-            {new Date(createdAt).toLocaleDateString('ko-KR', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </Text>
-          <Divider
-            orientation="vertical"
-            thickness="px"
-            color="bg-grey-200"
-            className="h-2.5"
-          />
-          <Text
-            variant="body-16-m"
-            color="grey-600"
-            className="whitespace-pre text-right"
-          >
-            조회수 {viewCount.toLocaleString()}
-          </Text>
         </div>
-      </div>
-      <div className="h-36 w-60 rounded-[12px] overflow-hidden flex-shrink-0">
-        <Image
-          src={thumbnailUrl}
-          alt={title}
-          width={240}
-          height={144}
-          className="object-cover w-full h-full"
-        />
-      </div>
-    </motion.div>
+      </motion.div>
+    </Link>
   );
 }

--- a/apps/teampage/src/shared/component/card/types.ts
+++ b/apps/teampage/src/shared/component/card/types.ts
@@ -1,5 +1,6 @@
 export type CardProps = {
   content: Content;
+  link: string;
   className?: string;
 };
 

--- a/apps/teampage/src/shared/component/markdown/Markdown.tsx
+++ b/apps/teampage/src/shared/component/markdown/Markdown.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Text } from '../Text';
+import Image from 'next/image';
+
+export const Markdown = ({ content }: { content: string }) => {
+  return (
+    <ReactMarkdown
+      components={{
+        p: ({ children }) => {
+          const hasImage = React.Children.toArray(children).some(
+            (child: any) => child?.type === 'img' || child?.props?.src,
+          );
+          if (hasImage) {
+            return <div className="mb-6">{children}</div>;
+          }
+          return (
+            <Text
+              variant="body-20-m"
+              color="grey-800"
+              className="mb-6 leading-relaxed"
+            >
+              {children}
+            </Text>
+          );
+        },
+        h1: ({ children }) => (
+          <Text
+            variant="title-36-b"
+            color="grey-900"
+            className="mb-6 mt-12"
+            as="h1"
+          >
+            {children}
+          </Text>
+        ),
+        h2: ({ children }) => (
+          <Text
+            variant="title-28-b"
+            color="grey-900"
+            className="mb-4 mt-10"
+            as="h2"
+          >
+            {children}
+          </Text>
+        ),
+        h3: ({ children }) => (
+          <Text
+            variant="title-24-b"
+            color="grey-900"
+            className="mb-4 mt-8"
+            as="h3"
+          >
+            {children}
+          </Text>
+        ),
+        strong: ({ children }) => (
+          <Text variant="body-20-b" color="grey-900" as="span">
+            {children}
+          </Text>
+        ),
+        code: ({ children }) => (
+          <code className="px-2 py-1 bg-grey-100 text-primary-ui rounded text-sm font-mono">
+            {children}
+          </code>
+        ),
+        pre: ({ children }) => (
+          <pre className="bg-grey-50 p-6 rounded-2xl overflow-x-auto mb-6 border border-grey-200">
+            {children}
+          </pre>
+        ),
+        ul: ({ children }) => (
+          <ul className="mb-6 pl-6 space-y-2 list-disc">{children}</ul>
+        ),
+        ol: ({ children }) => (
+          <ol className="mb-6 pl-6 space-y-2 list-decimal">{children}</ol>
+        ),
+        li: ({ children }) => (
+          <li>
+            <Text variant="body-20-m" color="grey-800" as="span">
+              {children}
+            </Text>
+          </li>
+        ),
+        img: ({ src, alt }) => (
+          <div className="my-8 w-full">
+            <div className="relative w-full" style={{ height: '400px' }}>
+              <Image
+                src={src || ''}
+                alt={alt || ''}
+                fill
+                className="rounded-2xl object-cover"
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 880px, 880px"
+              />
+            </div>
+            {alt && (
+              <Text
+                variant="body-16-m"
+                color="grey-500"
+                className="text-center mt-3"
+              >
+                {alt}
+              </Text>
+            )}
+          </div>
+        ),
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+};

--- a/apps/teampage/src/widgets/post/Post.tsx
+++ b/apps/teampage/src/widgets/post/Post.tsx
@@ -1,3 +1,8 @@
+import { PostSection } from '@/features/post/PostSection';
+import { mockPostData } from './mockPost';
+
 export async function Post({ id }: { id: string }) {
-  return <div>{id}</div>;
+  console.log('TODO: id 기반으로 데이터 조회', id);
+
+  return <PostSection type="tech" post={mockPostData} />;
 }

--- a/apps/teampage/src/widgets/post/mockPost.ts
+++ b/apps/teampage/src/widgets/post/mockPost.ts
@@ -1,0 +1,65 @@
+import { ArticleDetailResponse } from '@uoslife/api';
+
+export const mockPostData: ArticleDetailResponse = {
+  id: 1,
+  authorId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  authorName: '김개발',
+  title: 'Next.js 13 App Router 완전 정복하기',
+  category: 'DEVELOP',
+  summary:
+    'Next.js 13의 새로운 App Router를 활용한 모던 웹 개발 방법을 알아봅시다.',
+  content: `
+  # Next.js 13 App Router 완전 정복하기
+  
+  Next.js 13에서 도입된 App Router는 기존의 Pages Router와는 완전히 다른 패러다임을 제공합니다.
+  
+  ![Next.js App Router 구조도](https://images.unsplash.com/photo-1627398242454-45a1465c2479?w=800)
+  
+  ## 주요 특징
+  
+  1. **파일 시스템 기반 라우팅**
+  2. **Server Components 지원**
+  3. **Streaming과 Suspense**
+  4. **개선된 데이터 페칭**
+  
+  ![개발 환경 설정](https://images.unsplash.com/photo-1461749280684-dccba630e2f6?w=800)
+  
+  ## 시작하기
+  
+  \`\`\`bash
+  npx create-next-app@latest my-app --experimental-app
+  \`\`\`
+  
+  App Router를 사용하면 더욱 직관적이고 성능이 뛰어난 웹 애플리케이션을 구축할 수 있습니다.
+  
+  ![완성된 애플리케이션 예시](https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=800)
+    `,
+  viewCount: 1247,
+  thumbnailUrl:
+    'https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=800',
+  likeCount: 42,
+  createdAt: '2024-09-06T10:30:00Z',
+  prevArticle: {
+    id: 2,
+    writerId: '2fa85f64-5717-4562-b3fc-2c963f66afa6',
+    writerName: '박디자인',
+    title: '디자인 시스템 구축하기',
+    summary: '일관된 사용자 경험을 위한 디자인 시스템 구축 방법',
+    viewCount: 892,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1558655146-9f40138edfeb?w=800',
+    createdAt: new Date('2024-09-05T14:20:00Z'),
+  },
+  nextArticle: {
+    id: 3,
+    writerId: '4fa85f64-5717-4562-b3fc-2c963f66afa6',
+    writerName: '이마케팅',
+    title: '효과적인 콘텐츠 마케팅 전략',
+    summary: '타겟 오디언스에게 다가가는 콘텐츠 마케팅 노하우',
+    viewCount: 634,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=800',
+    createdAt: new Date('2024-09-07T09:15:00Z'),
+  },
+  comments: [{ id: 1 }, { id: 2 }, { id: 3 }],
+};

--- a/apps/teampage/tailwind.config.ts
+++ b/apps/teampage/tailwind.config.ts
@@ -56,6 +56,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 };
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@types/react-dom':
         specifier: ^18
         version: 18.3.0
+      '@uoslife/api':
+        specifier: workspace:*
+        version: link:../../packages/api
       '@uoslife/eslint-config':
         specifier: workspace:*
         version: link:../../packages/config-eslint
@@ -4531,7 +4534,7 @@ snapshots:
       eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1))
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.1)
       eslint-plugin-playwright: 0.16.0(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)
@@ -5239,7 +5242,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.1)
       eslint-plugin-react: 7.34.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -5260,7 +5263,7 @@ snapshots:
 
   eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)):
     dependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -5276,7 +5279,7 @@ snapshots:
       enhanced-resolve: 5.16.1
       eslint: 8.57.1
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -5293,7 +5296,7 @@ snapshots:
       enhanced-resolve: 5.16.1
       eslint: 8.57.1
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -5332,7 +5335,7 @@ snapshots:
       eslint: 8.57.1
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@notionhq/client':
         specifier: ^4.0.2
         version: 4.0.2
+      '@tailwindcss/typography':
+        specifier: ^0.5.16
+        version: 0.5.16(tailwindcss@3.4.17)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.84.2(react@18.3.1)
@@ -78,6 +81,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@18.3.3)(react@18.3.1)
       zod:
         specifier: ^4.0.17
         version: 4.0.17
@@ -774,6 +780,11 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@tailwindcss/typography@0.5.16':
+    resolution: {integrity: sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tanstack/query-core@5.83.1':
     resolution: {integrity: sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==}
 
@@ -790,8 +801,17 @@ packages:
     peerDependencies:
       react: ^17.0.1
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/es-aggregate-error@1.0.6':
     resolution: {integrity: sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -801,6 +821,12 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.14.0':
     resolution: {integrity: sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==}
@@ -819,6 +845,9 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1144,6 +1173,9 @@ packages:
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1208,6 +1240,9 @@ packages:
   caniuse-lite@1.0.30001627:
     resolution: {integrity: sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1215,6 +1250,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1251,6 +1298,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1347,6 +1397,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1377,6 +1430,9 @@ packages:
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1711,6 +1767,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1722,6 +1781,9 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1952,8 +2014,17 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -1998,6 +2069,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.4:
+    resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
@@ -2005,6 +2079,12 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
@@ -2067,6 +2147,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2089,6 +2172,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -2333,8 +2419,14 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
   lodash.isempty@4.4.0:
     resolution: {integrity: sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2364,6 +2456,9 @@ packages:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2390,6 +2485,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -2399,6 +2518,69 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2678,6 +2860,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -2768,6 +2953,10 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
@@ -2814,6 +3003,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   prosemirror-commands@1.7.1:
     resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
 
@@ -2856,6 +3048,12 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2909,6 +3107,12 @@ packages:
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
     hasBin: true
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3085,6 +3289,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -3140,6 +3347,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3163,6 +3373,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.17:
+    resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
+
+  style-to-object@1.0.9:
+    resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -3231,6 +3447,12 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
@@ -3387,6 +3609,24 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -3420,6 +3660,12 @@ packages:
   validator@13.15.15:
     resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
     engines: {node: '>= 0.10'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
@@ -3510,6 +3756,9 @@ packages:
 
   zod@4.0.17:
     resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4253,6 +4502,14 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.6.2
 
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17)':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.17
+
   '@tanstack/query-core@5.83.1': {}
 
   '@tanstack/react-query@5.84.2(react@18.3.1)':
@@ -4276,9 +4533,19 @@ snapshots:
       '@toast-ui/editor': 3.2.2
       react: 18.3.1
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/es-aggregate-error@1.0.6':
     dependencies:
       '@types/node': 20.14.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
+  '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -4287,6 +4554,12 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.14.0':
     dependencies:
@@ -4306,6 +4579,8 @@ snapshots:
       csstype: 3.1.3
 
   '@types/semver@7.5.8': {}
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -4727,6 +5002,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   binary-extensions@2.3.0: {}
@@ -4792,6 +5069,8 @@ snapshots:
 
   caniuse-lite@1.0.30001627: {}
 
+  ccount@2.0.1: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -4802,6 +5081,14 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -4844,6 +5131,8 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
 
@@ -4925,6 +5214,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -4948,6 +5241,10 @@ snapshots:
   detect-indent@7.0.1: {}
 
   detect-newline@4.0.1: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -5241,7 +5538,7 @@ snapshots:
       '@typescript-eslint/parser': 7.12.0(eslint@8.57.1)(typescript@5.5.4)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.1)
       eslint-plugin-react: 7.34.2(eslint@8.57.1)
@@ -5290,12 +5587,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.16.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -5318,14 +5615,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.12.0(eslint@8.57.1)(typescript@5.5.4)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5345,7 +5642,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.12.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -5585,6 +5882,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
 
   event-target-shim@5.0.1: {}
@@ -5600,6 +5899,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5847,7 +6148,33 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.17
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hosted-git-info@2.8.9: {}
+
+  html-url-attributes@3.0.1: {}
 
   htmlparser2@8.0.2:
     dependencies:
@@ -5884,6 +6211,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.4: {}
+
   internal-slot@1.0.7:
     dependencies:
       es-errors: 1.3.0
@@ -5895,6 +6224,13 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.4:
     dependencies:
@@ -5964,6 +6300,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.0.2:
@@ -5983,6 +6321,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-map@2.0.3: {}
 
@@ -6190,7 +6530,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.castarray@4.4.0: {}
+
   lodash.isempty@4.4.0: {}
+
+  lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
 
@@ -6209,6 +6553,8 @@ snapshots:
   loglevel-plugin-prefix@0.8.4: {}
 
   loglevel@1.9.2: {}
+
+  longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -6237,11 +6583,233 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.0
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdurl@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.1
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -6574,6 +7142,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.24.6
@@ -6638,6 +7216,11 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
@@ -6682,6 +7265,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@7.1.0: {}
 
   prosemirror-commands@1.7.1:
     dependencies:
@@ -6739,6 +7324,24 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-markdown@10.1.0(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 18.3.3
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react@18.3.1:
     dependencies:
@@ -6813,6 +7416,23 @@ snapshots:
   regjsparser@0.10.0:
     dependencies:
       jsesc: 0.5.0
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -7022,6 +7642,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -7108,6 +7730,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -7125,6 +7752,14 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.17:
+    dependencies:
+      style-to-object: 1.0.9
+
+  style-to-object@1.0.9:
+    dependencies:
+      inline-style-parser: 0.2.4
 
   styled-jsx@5.1.1(@babel/core@7.24.6)(react@18.3.1):
     dependencies:
@@ -7220,6 +7855,10 @@ snapshots:
       is-number: 7.0.0
 
   tr46@0.0.3: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@1.3.0(typescript@5.5.4):
     dependencies:
@@ -7386,6 +8025,39 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
   universalify@2.0.1: {}
 
   update-browserslist-db@1.0.16(browserslist@4.23.0):
@@ -7412,6 +8084,16 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validator@13.15.15: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   w3c-keyname@2.2.8: {}
 
@@ -7539,3 +8221,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.0.17: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

포스트 상세 페이지 기능을 구현했습니다.
- 마크다운 기반 포스트 렌더링 시스템 구축
- 포스트 헤더, 본문, 푸터 컴포넌트 분리
- 카드 컴포넌트에 링크 기능 추가
- 각 카테고리별 상세 페이지 라우팅 구현

---

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 적어주세요. close: #이슈 번호, #이슈 번호 -->

---

## 📷 스크린샷 (필요한 경우)

<!-- 포스트 상세 페이지의 스크린샷을 포함해주세요. -->

---

## 📋 체크리스트

- [x] 변경 사항이 정상적으로 동작하는지 확인했습니다.
- [x] 필요시 관련 문서를 업데이트했습니다.

---

## 💬 하고 싶은 말

### 주요 구현 내용
1. **마크다운 렌더링 시스템**
   - ReactMarkdown을 래핑한 Markdown 컴포넌트 구현
   - 이미지, 제목, 단락 등 각 요소별 커스텀 스타일링

2. **포스트 페이지 컴포넌트 구조화**
   - PostHeader: 제목, 카테고리, 메타데이터 표시
   - PostSection: 메인 포스트 컨텐츠 렌더링
   - PostFooter: 좋아요, 공유, 댓글 기능

3. **카드 컴포넌트 개선**
   - CardA, CardB에 외부 링크 주입 기능 추가
   - 각 카테고리별 상세 페이지 연결

4. **라우팅 구현**
   - `/career/[id]`, `/moments/[id]` 동적 라우트 추가
   - 각 페이지별 PostSection 통합

### 기술적 해결 사항
- Next.js Image 컴포넌트를 활용한 이미지 최적화
- 컴포넌트 분리를 통한 관심사 분리 및 재사용성 향상