### PR TITLE
[Feat] access token을 갱신하는 로직 구현

### DIFF
--- a/apps/teampage/package.json
+++ b/apps/teampage/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "catalog:",
     "@toast-ui/react-editor": "^3.2.3",
     "jotai": "^2.13.0",
+    "jwt-decode": "^4.0.0",
     "motion": "^12.23.12",
     "next": "catalog:",
     "next-auth": "catalog:",
@@ -24,8 +25,8 @@
     "react-textarea-autosize": "^8.5.9",
     "rxjs": "^7.8.2",
     "sharp": "^0.34.3",
-    "uuid": "^13.0.0",
     "tailwind-merge": "^3.3.1",
+    "uuid": "^13.0.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/apps/teampage/src/page/main-page/section/Section05.tsx
+++ b/apps/teampage/src/page/main-page/section/Section05.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Text } from '@shared/component/Text';
 import { TabButton } from '@shared/component/TabButton';
+import { Text } from '@shared/component/Text';
 import Image from 'next/image';
 import { HoverScaleAnimation } from '@/shared/component/animation/HoverScaleAnimation';
 import { useHorizontalScroll } from '@/shared/hooks/useHorizontalSrcoll';
@@ -117,8 +117,9 @@ function CurriculumCard({
           src={imageUrl}
           alt={title}
           fill
-          placeholder='blur' 
+          placeholder="blur"
           unoptimized
+          blurDataURL={imageUrl}
           className="rounded-[36px] object-cover"
         />
       </div>

--- a/apps/teampage/src/page/main-page/section/Section06.tsx
+++ b/apps/teampage/src/page/main-page/section/Section06.tsx
@@ -8,7 +8,8 @@ export function Section06() {
         src="/img/section06_bg.webp"
         alt="section06 background"
         fill
-        placeholder='blur' 
+        placeholder="blur"
+        blurDataURL="/img/section06_bg.webp"
         unoptimized
         className="object-cover -z-10"
       />

--- a/apps/teampage/src/page/main-page/section/Section09.tsx
+++ b/apps/teampage/src/page/main-page/section/Section09.tsx
@@ -9,8 +9,9 @@ export function Section09() {
         src="/img/section09_bg.webp"
         alt="section09 background"
         fill
-        placeholder='blur' 
+        placeholder="blur"
         unoptimized
+        blurDataURL="/img/section09_bg.webp"
         className="object-cover -z-10"
       />
       <div className="flex flex-col gap-9 items-start">

--- a/apps/teampage/src/shared/utils/jwt.ts
+++ b/apps/teampage/src/shared/utils/jwt.ts
@@ -1,0 +1,69 @@
+import { type JwtPayload, jwtDecode } from 'jwt-decode';
+
+const getTokenExpiration = (token: string): number | null => {
+  try {
+    const decoded = jwtDecode<JwtPayload>(token);
+    console.log(decoded);
+    if (decoded.exp) {
+      return decoded.exp;
+    }
+    return null;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
+
+export const isTokenExpired = (token: string): boolean => {
+  const exp = getTokenExpiration(token);
+  if (!exp) return true;
+  const now = Math.floor(Date.now() / 1000);
+  return exp < now;
+};
+
+export const getAccessTokenByRefreshToken = async (refreshToken: string) => {
+  const clientId = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_ID;
+  const clientSecret = process.env.NEXT_PUBLIC_KEYCLOAK_CLIENT_SECRET;
+  const issuer = process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER;
+
+  if (!clientId || !clientSecret || !issuer) {
+    throw new Error('Missing Keycloak configuration');
+  }
+
+  try {
+    const url = `${issuer}/protocol/openid-connect/token`;
+
+    const body = {
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken as string,
+    };
+
+    const urlencoded = new URLSearchParams(body);
+
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      method: 'POST',
+      body: urlencoded,
+    });
+
+    const resTokens = await response.json();
+
+    if (!response.ok) throw resTokens;
+
+    return {
+      accessToken: resTokens.access_token,
+      accessTokenExpires: Date.now() + resTokens.expires_in * 1000,
+      refreshToken: resTokens.refresh_token ?? refreshToken,
+    };
+  } catch (error) {
+    console.error(error);
+    throw {
+      refreshToken,
+      error: 'RefreshAccessTokenError',
+    };
+  }
+};

--- a/apps/teampage/src/shared/utils/jwt.ts
+++ b/apps/teampage/src/shared/utils/jwt.ts
@@ -3,7 +3,6 @@ import { type JwtPayload, jwtDecode } from 'jwt-decode';
 const getTokenExpiration = (token: string): number | null => {
   try {
     const decoded = jwtDecode<JwtPayload>(token);
-    console.log(decoded);
     if (decoded.exp) {
       return decoded.exp;
     }

--- a/packages/api/api-instance.ts
+++ b/packages/api/api-instance.ts
@@ -1,54 +1,6 @@
 import Axios, { type AxiosError, type AxiosRequestConfig } from 'axios';
 import type { Session } from 'next-auth';
-import { getSession, signOut } from 'next-auth/react';
-
-async function refreshAccessToken(token: { refreshToken: string }) {
-  const clientId = process.env.KEYCLOAK_CLIENT_ID;
-  const clientSecret = process.env.KEYCLOAK_CLIENT_SECRET;
-  const issuer = process.env.KEYCLOAK_ISSUER;
-
-  if (!clientId || !clientSecret || !issuer) {
-    throw new Error('Missing Keycloak configuration');
-  }
-
-  try {
-    const url = `${issuer}/protocol/openid-connect/token`;
-
-    const body = {
-      grant_type: 'refresh_token',
-      client_id: clientId,
-      client_secret: clientSecret,
-      refresh_token: token.refreshToken as string,
-    };
-
-    const urlencoded = new URLSearchParams(body);
-
-    const response = await fetch(url, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      method: 'POST',
-      body: urlencoded,
-    });
-
-    const refreshedTokens = await response.json();
-
-    if (!response.ok) throw refreshedTokens;
-
-    return {
-      ...token,
-      accessToken: refreshedTokens.access_token,
-      accessTokenExpires: Date.now() + refreshedTokens.expires_in * 1000,
-      refreshToken: refreshedTokens.refresh_token ?? token.refreshToken,
-    };
-  } catch (error) {
-    console.error(error);
-    throw {
-      ...token,
-      error: 'RefreshAccessTokenError',
-    };
-  }
-}
+import { getSession } from 'next-auth/react';
 
 type SessionType = {
   accessToken: string;
@@ -56,8 +8,6 @@ type SessionType = {
 } & Session;
 
 const DEFAULT_TIMEOUT_MS = 10 * 1000;
-
-const MAX_RETRY_COUNT = 3;
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: 'https://apis.uoslife.team',
@@ -71,46 +21,6 @@ AXIOS_INSTANCE.interceptors.request.use(async (config) => {
   }
   return config;
 });
-
-AXIOS_INSTANCE.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  async (error: AxiosError) => {
-    const originalRequest = error.config as AxiosRequestConfig & {
-      _retry?: boolean;
-      _retryCount?: number;
-    };
-
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-      originalRequest._retryCount = (originalRequest._retryCount || 0) + 1;
-
-      if (originalRequest._retryCount > MAX_RETRY_COUNT) {
-        return Promise.reject(error);
-      }
-
-      try {
-        const session = (await getSession()) as SessionType;
-
-        const token = await refreshAccessToken({
-          refreshToken: session?.refreshToken as string,
-        });
-        originalRequest.headers = {
-          ...originalRequest.headers,
-          Authorization: `Bearer ${token.accessToken}`,
-        };
-        return AXIOS_INSTANCE(originalRequest);
-      } catch (refreshError) {
-        alert('세션이 만료되었습니다. 다시 로그인해주세요.');
-        signOut({ callbackUrl: '/' });
-        return Promise.reject(refreshError);
-      }
-    }
-
-    return Promise.reject(error);
-  },
-);
 
 export const apiInstance = <T>(
   config: AxiosRequestConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       jotai:
         specifier: ^2.13.0
         version: 2.13.0(@babel/core@7.24.6)(@babel/template@7.24.6)(@types/react@18.3.3)(react@18.3.1)
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       motion:
         specifier: ^12.23.12
         version: 12.23.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -74,7 +77,7 @@ importers:
         version: 14.2.31(@babel/core@7.24.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: 'catalog:'
-        version: 4.24.11(next@14.2.31(@babel/core@7.24.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -150,7 +153,7 @@ importers:
         version: 1.12.1
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@14.2.31(@babel/core@7.24.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.11(next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -2575,6 +2578,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -6889,6 +6896,8 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
+  jwt-decode@4.0.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7272,7 +7281,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-auth@4.24.11(next@14.2.31(@babel/core@7.24.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.11(next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.6
       '@panva/hkdf': 1.2.1


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- next-auth callback 단에서 토큰을 refresh해오는 로직을 구현했습니다.
    - jwt callback의 토큰의 만료시간(`exp`)과 실제 토큰의 만료시간이 서로 맞지않아, 직접 jwt를 decode하여 만료 여부를 확인하도록 구현했습니다.
    - [keycloak endpoint](https://www.keycloak.org/securing-apps/oidc-layers#_token_endpoint)에서 직접 refresh token을 이용해 새 토큰을 가져옵니다.

- `Image` 컴포넌트에서 `blurDataURL`를 설정하지 않아 발생하는 runtime 에러를 수정했습니다. (cc. @gonn-i )