### PR TITLE
[fix] 노션 데이터 베이스 이미지 변경에 대비해 next 서버 public에 이미지 저장하도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # environment variables
 .env
+
+# downloaded images from Notion
+apps/teampage/public/images/people/

--- a/apps/teampage/src/features/notion/NotionManager.ts
+++ b/apps/teampage/src/features/notion/NotionManager.ts
@@ -1,9 +1,11 @@
-import { SingletonRegister, Singletons } from "@shared/utils/SingletonRegistry";
-import { NotionClient } from "./NotionClient";
-import { NotionUtil } from "./NotionUtil";
-import type { PeopleData, NotionListResponse } from "./NotionType";
+import { SingletonRegister, Singletons } from '@shared/utils/SingletonRegistry';
+import { NotionClient } from './NotionClient';
+import { NotionUtil } from './NotionUtil';
+import type { PeopleData, NotionListResponse } from './NotionType';
+import fs from 'fs';
+import path from 'path';
 
-const TOKEN = "NOTION_MANAGER" as const;
+const TOKEN = 'NOTION_MANAGER' as const;
 @SingletonRegister(TOKEN)
 export class NotionManager {
   public static TOKEN = TOKEN;
@@ -11,7 +13,7 @@ export class NotionManager {
   private getNotionList = async (): Promise<NotionListResponse> => {
     const notion = Singletons[NotionClient.TOKEN].getInstance();
     if (!process.env.NOTION_PEOPLE_DATABASE_ID) {
-      throw new Error("NOTION_PEOPLE_DATABASE_ID is not set");
+      throw new Error('NOTION_PEOPLE_DATABASE_ID is not set');
     }
 
     const response = await notion.databases.query({
@@ -21,22 +23,63 @@ export class NotionManager {
     return NotionUtil.parseNotionList(response);
   };
 
+  private downloadAndSaveImage = async (
+    notionImageUrl: string,
+    personName: string,
+  ): Promise<string> => {
+    try {
+      const safeName = personName.replace(/[^a-zA-Z0-9가-힣]/g, '_');
+      const filename = `${safeName}.jpg`;
+      const imagesDir = path.join(process.cwd(), 'public', 'images', 'people');
+      const filepath = path.join(imagesDir, filename);
+      if (fs.existsSync(filepath)) {
+        return `/images/people/${filename}`;
+      }
+
+      if (!fs.existsSync(imagesDir)) {
+        fs.mkdirSync(imagesDir, { recursive: true });
+      }
+
+      const response = await fetch(notionImageUrl);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch image: ${response.status}`);
+      }
+
+      const buffer = await response.arrayBuffer();
+      await fs.promises.writeFile(filepath, new Uint8Array(buffer));
+
+      return `/images/people/${filename}`;
+    } catch (error) {
+      console.error('Failed to download image:', error);
+      return notionImageUrl;
+    }
+  };
+
   public getPeopleData = async (): Promise<PeopleData[]> => {
     try {
       const list = await this.getNotionList();
-      const peopleData: PeopleData[] = list.results.map((page) => {
-        return NotionUtil.convertToPeopleData(page);
-      });
+      const peopleData: PeopleData[] = await Promise.all(
+        list.results.map(async (page) => {
+          const data = NotionUtil.convertToPeopleData(page);
+          if (data.image_profile) {
+            data.image_profile = await this.downloadAndSaveImage(
+              data.image_profile,
+              data.name,
+            );
+          }
+          return data;
+        }),
+      );
 
       return peopleData;
     } catch (error) {
-      console.error("Failed to get people data from Notion", error);
+      console.error('Failed to get people data from Notion', error);
       return [];
     }
   };
 }
 
-declare module "@shared/utils/SingletonRegistry" {
+declare module '@shared/utils/SingletonRegistry' {
   interface SingletonRegistry {
     [TOKEN]: NotionManager;
   }


### PR DESCRIPTION
### 주요 수정사항
- 노션 DB 이미지가 1시간 간격으로 변경되어, SSG 사용 시 엑스박스 뜨는 현상 수정 PR
- **노션 이미지 로컬 저장 기능 추가**: 노션 데이터베이스에서 가져온 이미지를 Next.js 서버의 `public/images/people/` 폴더에 다운로드하여 저장
- **이미지 중복 다운로드 방지**: 이미 존재하는 이미지는 재다운로드하지 않고 기존 파일 사용
- **안전한 파일명 처리**: 한글 이름을 안전한 파일명으로 변환하여 저장
- **에러 핸들링**: 이미지 다운로드 실패 시 원본 URL로 fallback

### 수정된 파일
- `apps/teampage/src/features/notion/NotionManager.ts`
- `.gitignore` (다운로드된 이미지 폴더 제외)

### 기술적 개선사항
- `downloadAndSaveImage` 메서드 추가로 이미지 다운로드 및 저장 로직 구현
- `Promise.all`을 사용하여 병렬 처리로 성능 최적화
- 파일 시스템 체크를 통한 중복 다운로드 방지
- 안전한 디렉토리 생성 (`recursive: true`)

### 해결된 문제
- 노션 데이터베이스의 이미지 URL이 변경되어도 로컬에 저장된 이미지를 사용할 수 있음
- 외부 의존성 감소로 이미지 로딩 안정성 향상

### 체크리스트
- [x] 코드 리뷰 완료
- [x] 기존 기능에 영향 없음 확인
- [x] 에러 핸들링 구현