### PR TITLE
[Feat] 게시글 조회 관련 2차 QA 반영

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           echo "NEXT_PUBLIC_KEYCLOAK_CLIENT_SECRET=dummy" >> apps/teampage/.env
           echo "NEXT_PUBLIC_KEYCLOAK_ISSUER=dummy" >> apps/teampage/.env
           echo "NEXT_PUBLIC_AMPLITUDE_API_KEY=dummy" >> apps/teampage/.env
+          echo "NEXT_PUBLIC_NEXTAUTH_URL=dummy" >> apps/teampage/.env
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -64,6 +64,7 @@ jobs:
           echo "NEXT_PUBLIC_KEYCLOAK_CLIENT_SECRET=$NEXT_PUBLIC_KEYCLOAK_CLIENT_SECRET" >> apps/teampage/.env
           echo "NEXT_PUBLIC_KEYCLOAK_ISSUER=$NEXT_PUBLIC_KEYCLOAK_ISSUER" >> apps/teampage/.env
           echo "NEXT_PUBLIC_AMPLITUDE_API_KEY=$NEXT_PUBLIC_AMPLITUDE_API_KEY" >> apps/teampage/.env
+          echo "NEXT_PUBLIC_NEXTAUTH_URL=$NEXT_PUBLIC_NEXTAUTH_URL" >> apps/teampage/.env
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
           NOTION_PEOPLE_DATABASE_ID: ${{ secrets.NOTION_PEOPLE_DATABASE_ID }}
@@ -76,6 +77,7 @@ jobs:
           NEXT_PUBLIC_KEYCLOAK_CLIENT_SECRET: ${{ secrets.KEYCLOAK_CLIENT_SECRET }}
           NEXT_PUBLIC_KEYCLOAK_ISSUER: ${{ secrets.KEYCLOAK_ISSUER }}
           NEXT_PUBLIC_AMPLITUDE_API_KEY: ${{ secrets.NEXT_PUBLIC_AMPLITUDE_API_KEY }}
+          NEXT_PUBLIC_NEXTAUTH_URL: ${{ secrets.NEXT_PUBLIC_NEXTAUTH_URL }}
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -109,6 +111,7 @@ jobs:
             NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}
             NEXTAUTH_URL=${{ secrets.NEXTAUTH_URL }}
             NEXT_PUBLIC_AMPLITUDE_API_KEY=${{ secrets.NEXT_PUBLIC_AMPLITUDE_API_KEY }}
+            NEXT_PUBLIC_NEXTAUTH_URL=${{ secrets.NEXT_PUBLIC_NEXTAUTH_URL }}
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.VERSION }}
             ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest

--- a/apps/teampage/next.config.mjs
+++ b/apps/teampage/next.config.mjs
@@ -8,6 +8,7 @@ const nextConfig = {
     return config;
   },
   images: {
+    dangerouslyAllowSVG: true,
     remotePatterns: [
       // TODO: mock 이미지를 위한 임시 추가
       {
@@ -37,6 +38,12 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'notion.so',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'd544kp0ugcek4.cloudfront.net',
         port: '',
         pathname: '/**',
       },

--- a/apps/teampage/src/app/auth.ts
+++ b/apps/teampage/src/app/auth.ts
@@ -40,6 +40,7 @@ const getAuthOptions = (): NextAuthOptions => {
             ...token,
             accessToken: account.access_token,
             refreshToken: account.refresh_token,
+            idToken: account.id_token,
           };
           return newToken;
         }
@@ -70,6 +71,7 @@ const getAuthOptions = (): NextAuthOptions => {
           ...session,
           accessToken: token.accessToken,
           refreshToken: token.refreshToken,
+          idToken: token.idToken,
         };
       },
     },

--- a/apps/teampage/src/app/career/[id]/page.tsx
+++ b/apps/teampage/src/app/career/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { Post } from '@/widgets/post/Post';
 
 export default function CareerPostPage({ params }: { params: { id: number } }) {
-  return <Post id={params.id} category="career" />;
+  return <Post id={params.id} category="CAREER" />;
 }

--- a/apps/teampage/src/app/moments/[id]/page.tsx
+++ b/apps/teampage/src/app/moments/[id]/page.tsx
@@ -5,5 +5,5 @@ export default function MomentsPostPage({
 }: {
   params: { id: number };
 }) {
-  return <Post id={params.id} category="moments" />;
+  return <Post id={params.id} category="MOMENTS" />;
 }

--- a/apps/teampage/src/app/tech/[id]/page.tsx
+++ b/apps/teampage/src/app/tech/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { Post } from '@/widgets/post/Post';
 
 export default function TechPostPage({ params }: { params: { id: number } }) {
-  return <Post id={params.id} category="tech" />;
+  return <Post id={params.id} category="TECH" />;
 }

--- a/apps/teampage/src/entities/auth/useAuth.ts
+++ b/apps/teampage/src/entities/auth/useAuth.ts
@@ -6,6 +6,7 @@ import { Session } from 'next-auth';
 type SessionType = {
   accessToken: string;
   refreshToken: string;
+  idToken: string;
 } & Session;
 
 const parseUserName = (name: string) => {
@@ -36,10 +37,30 @@ export const useAuth = () => {
     }
   }, [rawSession]);
 
+  const handleSignOut = async () => {
+    signOut({ redirect: false });
+    if (!process.env.NEXT_PUBLIC_NEXTAUTH_URL || !session)
+      throw new Error('NEXT_PUBLIC_NEXTAUTH_URL is not defined');
+
+    // keycloak server에서 로그아웃 시키도록 수정
+
+    const keycloakLogoutUrl =
+      `${process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER}/protocol/openid-connect/logout?` +
+      `redirect_uri=${encodeURIComponent(process.env.NEXT_PUBLIC_NEXTAUTH_URL)}`;
+
+    // TODO: 로그아웃시, 로그아웃 페이지에서 진행하지 않고 바로 홈페이지로 redirect 하도록 수정 필요
+    // const keycloakLogoutUrl =
+    //   `${process.env.NEXT_PUBLIC_KEYCLOAK_ISSUER}/protocol/openid-connect/logout?` +
+    //   `id_token_hint=${session?.idToken}&` +
+    //   `post_logout_redirect_uri=${encodeURIComponent(process.env.NEXT_PUBLIC_NEXTAUTH_URL)}`;
+
+    window.location.href = keycloakLogoutUrl;
+  };
+
   return {
     session,
     status,
     signIn,
-    signOut,
+    signOut: handleSignOut,
   };
 };

--- a/apps/teampage/src/features/post/PostHeader.tsx
+++ b/apps/teampage/src/features/post/PostHeader.tsx
@@ -6,12 +6,11 @@ import { useConfirmModal } from '@/shared/component/confirm-modal';
 import { Tag } from '@/shared/component/Tag';
 import { Text } from '@/shared/component/Text';
 import { useToast } from '@/shared/component/toast';
-
-export type PostType = 'tech' | 'career' | 'moments';
+import { SpaceType } from '@/shared/const/category';
 
 interface PostHeaderProps {
   post: ArticleDetailResponse;
-  type: PostType;
+  type: SpaceType;
 }
 
 export const PostHeader = (props: PostHeaderProps) => {
@@ -65,7 +64,7 @@ export const PostHeader = (props: PostHeaderProps) => {
           >
             {new Date(post.createdAt).toLocaleDateString('ko-KR')}
           </Text>
-          {type === 'tech' && (
+          {type === 'TECH' && (
             <>
               <div className="bg-grey-400 h-2.5 w-px" />
               <Text
@@ -84,6 +83,7 @@ export const PostHeader = (props: PostHeaderProps) => {
             <button
               type="button"
               onClick={() => {
+                console.log(post, type);
                 sessionStorage.setItem('editPost', JSON.stringify(post));
                 window.location.href = `/write?edit=true&from=${type}`;
               }}

--- a/apps/teampage/src/features/post/PostSection.tsx
+++ b/apps/teampage/src/features/post/PostSection.tsx
@@ -5,10 +5,11 @@ import { useNonMemberId } from '@/entities/member-id/useNonmemberId';
 import { ErrorFallback } from '@/shared/component/ErrorFallback';
 import { Markdown } from '@/shared/component/markdown/Markdown';
 import { PostFooter } from './PostFooter';
-import { PostHeader, type PostType } from './PostHeader';
+import { PostHeader } from './PostHeader';
 import { PrevNext } from './PrevNext';
+import { SpaceType } from '@/shared/const/category';
 
-export function PostSection({ type, id }: { type: PostType; id: number }) {
+export function PostSection({ type, id }: { type: SpaceType; id: number }) {
   const { nonMemberId } = useNonMemberId();
   const { data: post } = useFindArticle(id, {
     nonMemberId: nonMemberId,

--- a/apps/teampage/src/page/main-page/section/Section07.tsx
+++ b/apps/teampage/src/page/main-page/section/Section07.tsx
@@ -49,20 +49,22 @@ export function Section07() {
 }
 
 function TechArticleList() {
-  const{ data, isLoading }=  useSearchArticlesInfinite({
-    spaceId: SpaceIdEnum.TECH,
-    page: 0,
-    size: 10,
-    sortBy: 'CREATED_AT',
-    sortOrder: 'DESC',
-  }, 
+  const { data, isLoading } = useSearchArticlesInfinite(
+    {
+      spaceId: SpaceIdEnum.TECH,
+      page: 0,
+      size: 10,
+      sortBy: 'CREATED_AT',
+      sortOrder: 'DESC',
+    },
     {
       query: {
         getNextPageParam: () => {
           return undefined;
         },
       },
-    },);
+    },
+  );
   const techArticleContents = data?.pages[0].content;
 
   if (isLoading || !techArticleContents)
@@ -78,7 +80,7 @@ function TechArticleList() {
     <div className="grid grid-cols-2 gap-8 max-w-pc w-full">
       {techArticleContents
         .map((c) =>
-          !c.thumbnailUrl ? { ...c, thumbnailUrl: 'svg/roomae_03.svg' } : c,
+          !c.thumbnailUrl ? { ...c, thumbnailUrl: '/svg/roomae_03.svg' } : c,
         )
         .map((data) => (
           <Card.A link={`/tech/${data.id}`} key={data.title} content={data} />

--- a/apps/teampage/src/page/main-page/section/Section09.tsx
+++ b/apps/teampage/src/page/main-page/section/Section09.tsx
@@ -35,7 +35,7 @@ export function Section09() {
           </Text>
         </div>
         <Link
-          href="https://docs.google.com/forms/d/1O61Rt-m2OOX9KbCMG-CtkGR-2ytaEgsRiXB2STQKxi4/edit"
+          href="https://forms.gle/JntWWCzKjzRwZbaJ7"
           target="_blank"
           className="bg-white px-7 py-4 rounded-[32px]"
           onClick={() => {

--- a/apps/teampage/src/page/moments-page/MomentsMainSection.tsx
+++ b/apps/teampage/src/page/moments-page/MomentsMainSection.tsx
@@ -99,7 +99,7 @@ function ArticleList() {
   if (articles.length === 0) return <ArticleListEmptyContainer />;
 
   return (
-    <div className="grid grid-cols-1 gap-y-10 max-w-pc w-full">
+    <div className="grid grid-cols-2 gap-y-10 gap-x-6 max-w-pc w-full">
       {articles.map((content) => (
         <Card.A
           key={content.id}

--- a/apps/teampage/src/page/write-page/WritePage.tsx
+++ b/apps/teampage/src/page/write-page/WritePage.tsx
@@ -100,7 +100,6 @@ export default function WritePage() {
         const post = JSON.parse(savedPost);
         const processedContent = post.content?.replace(/\\n/g, '\n');
         setTitle(post.title || '');
-        setSpace(post.space);
         setContent(processedContent || '');
         setCategory(post.category || '');
         setSummary(post.summary || '');

--- a/apps/teampage/src/page/write-page/WritePage.tsx
+++ b/apps/teampage/src/page/write-page/WritePage.tsx
@@ -251,7 +251,7 @@ export default function WritePage() {
                 tab_name: getTabName(space),
               });
               alert('게시글 등록이 완료되었어요.');
-              // window.location.href = `/${space.toLowerCase()}/${res.id}`;
+              window.location.href = `/${space.toLowerCase()}/${res.id}`;
             },
             onError: (error) => {
               alert(

--- a/apps/teampage/src/page/write-page/WritePage.tsx
+++ b/apps/teampage/src/page/write-page/WritePage.tsx
@@ -93,6 +93,7 @@ export default function WritePage() {
         const post = JSON.parse(savedPost);
         const processedContent = post.content?.replace(/\\n/g, '\n');
         setTitle(post.title || '');
+        setSpace(post.space);
         setContent(processedContent || '');
         setCategory(post.category || '');
         setSummary(post.summary || '');

--- a/apps/teampage/src/page/write-page/WritePage.tsx
+++ b/apps/teampage/src/page/write-page/WritePage.tsx
@@ -144,7 +144,12 @@ export default function WritePage() {
       return isEmpty(category) || isEmpty(summary) || isOverMaxLength(summary);
     }
 
-    return isEmpty(category) || isEmpty(summary);
+    return (
+      isEmpty(category) ||
+      isEmpty(summary) ||
+      thumbnailFile === null ||
+      isOverMaxLength(summary)
+    );
   }, [title, summary, content, category, thumbnailFile, isCareer, isMoments]);
 
   const handleFileSelect = (file: File) => {

--- a/apps/teampage/src/page/write-page/processArticle.ts
+++ b/apps/teampage/src/page/write-page/processArticle.ts
@@ -15,6 +15,10 @@ export type CreateArticleInput = Omit<CreateArticleRequest, 'thumbnailUrl'> & {
   thumbnailFile?: File | null;
 };
 
+const addHttpsPrifix = (url: string) => {
+  return `https://${url}`;
+};
+
 const base64ToFile = (dataUrl: string): Observable<File> => {
   try {
     // data:image/png;base64,iVBORw0KGgo... 형태에서 base64 부분만 추출
@@ -130,7 +134,7 @@ const uploadThumbnailToServer = (
       .then((result) => {
         console.log(result);
         if (result.url) {
-          observer.next(result.url);
+          observer.next(addHttpsPrifix(result.url));
           observer.complete();
         } else {
           observer.error('No thumbnail URL in response');
@@ -215,7 +219,7 @@ export const processArticle = (
             ).pipe(
               map((serverImageUrl) => ({
                 oldString: file.oldString,
-                newUrl: `https://${serverImageUrl}`,
+                newUrl: addHttpsPrifix(serverImageUrl),
               })),
             ),
           );

--- a/apps/teampage/src/widgets/post/Post.tsx
+++ b/apps/teampage/src/widgets/post/Post.tsx
@@ -1,11 +1,12 @@
 'use client';
 import { PostSection } from '@/features/post/PostSection';
-import { PostType } from '@/features/post/PostHeader';
 import { useSendViewAmplitudeEvent } from '@/entities/analytics/useSendViewAmplitudeEvent';
+import { SpaceType } from '@/shared/const/category';
+import { TabName } from '@/entities/analytics/AmplitudePropertyType';
 
-export function Post({ id, category }: { id: number; category: PostType }) {
+export function Post({ id, category }: { id: number; category: SpaceType }) {
   useSendViewAmplitudeEvent('VIEW_ARTICLE', {
-    tab_name: category,
+    tab_name: category.toLowerCase() as TabName,
     article_id: id.toString(),
   });
   return <PostSection type={category} id={id} />;


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 게시글 수정 mutation 추가
- image url에 https:// string을 붙이도록 수정
- image 렌더링시 svg allow 및 cloudfront host 추가
- 업로드시 버튼이 업로드중 문구가 표시되도록 수정 및 뒤로가기 warning 추가
- PostType을 기존 SpaceType으로 통일
- svg 로딩 에러 수정
- 모집 알림 받기 링크 수정
- moments 탭의 리스트 레이아웃을 2줄로 변경
- 로그인시 id_token 값을 session에 추가하도록 수정
- 로그아웃시 keycloak server에서 로그아웃 시키도록 수정
- NEXT_PUBLIC_NEXTAUTH_URL 추가
- tech 탭에서 썸네일을 무조건 받도록 수정
- 게시글 등록 완료 후 redirect 코드 주석 해제