### PR TITLE
Feature(recuit): 상반기 6th 추가모집 관련 변경사항 반영

### DIFF
--- a/apps/teampage/src/page/Recruiting-page/Recruitingpage.tsx
+++ b/apps/teampage/src/page/Recruiting-page/Recruitingpage.tsx
@@ -10,8 +10,6 @@ import { Section07 } from './section/Section07';
 import { Recruitbutton } from './section/Recruitbutton';
 import { useSendViewAmplitudeEvent } from '@/entities/analytics/useSendViewAmplitudeEvent';
 
-export const ISINRANGE = false;
-
 export default function RecruitingPage() {
   const ref5 = useRef<HTMLDivElement>(null);
   const [showButton, setShowButton] = useState(true);

--- a/apps/teampage/src/page/Recruiting-page/config.ts
+++ b/apps/teampage/src/page/Recruiting-page/config.ts
@@ -1,0 +1,128 @@
+/**
+ * 리크루팅 페이지에서 시즌마다 바뀔 수 있는 카피·일정·에셋 경로를 한곳에서 관리합니다.
+ */
+
+export const recruitingAssets = {
+  heroLogoBackground: '/img/recruit/logo.png',
+} as const;
+
+export const recruitingBrand = {
+  name: 'UOSLIFE',
+  /** 예: 7기 모집 */
+  cohortLabel: '6기 모집',
+} as const;
+
+/**
+ * 일정·히어로 등 모든 노출 일자의 단일 소스.
+ * 표기 형식: `M월 D일(요일)` — 요일 없는 짧은 문구는 `recruitingDateWithoutWeekday`로 파생합니다.
+ */
+export const recruitingDates = {
+  documentSubmission: {
+    open: '11월 24일(월)',
+    due: '11월 30일(일)',
+    dueTimeNote: '오후 11시 59분 까지',
+  },
+  firstRoundResult: '12월 2일(화)',
+  secondInterview: {
+    start: '12월 3일(수)',
+    end: '12월 6일(토)',
+  },
+  finalResult: '12월 7일(일)',
+  onboarding: '12월 28일(일)',
+  workshop: {
+    start: '1월 3일(토)',
+    end: '1월 4일(일)',
+  },
+} as const;
+
+/** `11월 24일(월)` → `11월 24일` — 히어로 기간 문구 등에 사용 */
+export function recruitingDateWithoutWeekday(dayLabel: string): string {
+  return dayLabel.replace(/\s*\([^)]*\)\s*$/, '').trim();
+}
+
+/** 히어로(Section01) — 서류 접수 일정과 동일 소스 */
+export const recruitingPeriod = {
+  rangeStartLabel: `${recruitingDateWithoutWeekday(recruitingDates.documentSubmission.open)}부터`,
+  rangeEndLabel: `${recruitingDateWithoutWeekday(recruitingDates.documentSubmission.due)}까지`,
+} as const;
+
+/** Section04 상단 헤드라인 */
+export const recruitingHeadline = {
+  lines: ['IT 기술을 통해', '서울시립대학교 구성원을', '연결하는 프로덕트를'] as const,
+  lastLinePrefix: '만들어갈 인재를 ',
+  lastLineSuffix: '모집합니다.',
+} as const;
+
+export const recruitingTargetAudience = {
+  sectionTitle: '모집 대상',
+  primaryTitle: 'IT 서비스에 관심 있는 서울시립대학교 재학생 및 졸업생',
+  primaryNote: '졸업생의 경우, 졸업 후 0~2년 재직자에 한함',
+  durationRequirement: '최소 1년(2학기) 이상 활동할 수 있는 사람',
+} as const;
+
+export const recruitingSectionTitles = {
+  fields: { line1: '모집 분야 및', line2: '우대 사항' },
+  schedule: '모집 일정',
+} as const;
+
+export type RecruitingScheduleEntry =
+  | {
+      kind: 'documentSubmission';
+      title: string;
+      openDate: string;
+      dueDate: string;
+      dueTimeNote: string;
+    }
+  | {
+      kind: 'singleDay';
+      title: string;
+      date: string;
+      footnote?: string;
+    }
+  | {
+      kind: 'dateRange';
+      title: string;
+      startDate: string;
+      endDate: string;
+      footnote?: string;
+    };
+
+export const recruitingSchedule: RecruitingScheduleEntry[] = [
+  {
+    kind: 'documentSubmission',
+    title: '1차 서류 모집',
+    openDate: recruitingDates.documentSubmission.open,
+    dueDate: recruitingDates.documentSubmission.due,
+    dueTimeNote: recruitingDates.documentSubmission.dueTimeNote,
+  },
+  {
+    kind: 'singleDay',
+    title: '1차 결과 발표',
+    date: recruitingDates.firstRoundResult,
+  },
+  {
+    kind: 'dateRange',
+    title: '2차 대면 면접',
+    startDate: recruitingDates.secondInterview.start,
+    endDate: recruitingDates.secondInterview.end,
+    footnote: '*면접 일정 및 장소는 추후 안내',
+  },
+  {
+    kind: 'singleDay',
+    title: '최종 결과 발표',
+    date: recruitingDates.finalResult,
+    footnote: '*개별 안내 예정',
+  },
+  {
+    kind: 'singleDay',
+    title: '합격자 온보딩',
+    date: recruitingDates.onboarding,
+  },
+  {
+    kind: 'dateRange',
+    title: '합격자 워크샵',
+    startDate: recruitingDates.workshop.start,
+    endDate: recruitingDates.workshop.end,
+    footnote: '*1박 2일 참여 필수',
+  },
+];

--- a/apps/teampage/src/page/Recruiting-page/config.ts
+++ b/apps/teampage/src/page/Recruiting-page/config.ts
@@ -29,20 +29,20 @@ export function recruitingApplyButtonLabel(): string {
  */
 export const recruitingDates = {
   documentSubmission: {
-    open: '11월 24일(월)',
-    due: '11월 30일(일)',
+    open: '5월 4일(월)',
+    due: '5월 10일(일)',
     dueTimeNote: '오후 11시 59분 까지',
   },
-  firstRoundResult: '12월 2일(화)',
+  firstRoundResult: '5월 17일(일)',
   secondInterview: {
-    start: '12월 3일(수)',
-    end: '12월 6일(토)',
+    start: '5월 27일(수)',
+    end: '5월 30일(토)',
   },
-  finalResult: '12월 7일(일)',
-  onboarding: '12월 28일(일)',
+  finalResult: '5월 31일(일)',
+  onboarding: '6월 27일(토)',
   workshop: {
-    start: '1월 3일(토)',
-    end: '1월 4일(일)',
+    start: '7월 11일(토)',
+    end: '7월 12일(일)',
   },
 } as const;
 

--- a/apps/teampage/src/page/Recruiting-page/config.ts
+++ b/apps/teampage/src/page/Recruiting-page/config.ts
@@ -12,6 +12,17 @@ export const recruitingBrand = {
   cohortLabel: '6기 모집',
 } as const;
 
+export const recruitingCallToAction = {
+  applyFormUrl: 'https://docs.google.com/forms/d/e/1FAIpQLSeBv_mC-gD4WdQAbYZ6RPHDmuiHLey44AaU5XBeDgxLkSqcKQ/viewform',
+  notifyFormUrl: 'http://forms.gle/JntWWCzKjzRwZbaJ7',
+  notifyLabel: '다음 모집 알림 받기',
+} as const;
+
+/** 지원하기 버튼 라벨 — `cohortLabel`(예: `6기 모집`)과 단일 소스 */
+export function recruitingApplyButtonLabel(): string {
+  return `${recruitingBrand.cohortLabel.replace(/\s*모집\s*$/, '').trim()} 지원하기`;
+}
+
 /**
  * 일정·히어로 등 모든 노출 일자의 단일 소스.
  * 표기 형식: `M월 D일(요일)` — 요일 없는 짧은 문구는 `recruitingDateWithoutWeekday`로 파생합니다.
@@ -34,6 +45,49 @@ export const recruitingDates = {
     end: '1월 4일(일)',
   },
 } as const;
+
+/**
+ * 서류 접수(`documentSubmission`) 일정이 적용되는 연도 — 한국 시간(KST) 기준 달력 연도.
+ * 매 모집 시즌 바뀔 때 월·일과 함께 이 값도 맞춰 수정합니다.
+ */
+export const recruitingApplicationSeasonYear = 2026;
+
+function parseMonthDayFromRecruitingLabel(label: string): { month: number; day: number } {
+  const matched = label.match(/(\d+)\s*월\s*(\d+)\s*일/);
+  if (!matched) {
+    throw new Error(`Invalid recruiting date label: ${label}`);
+  }
+  return { month: Number(matched[1]), day: Number(matched[2]) };
+}
+
+/** 한국 시간 시·분을 해당 순간의 UTC `Date`로 변환 */
+function recruitingInstantKST(
+  year: number,
+  month: number,
+  day: number,
+  hour = 0,
+  minute = 0,
+  second = 0,
+  ms = 0,
+): Date {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const msStr = String(ms).padStart(3, '0');
+  return new Date(`${year}-${pad(month)}-${pad(day)}T${pad(hour)}:${pad(minute)}:${pad(second)}.${msStr}+09:00`);
+}
+
+/**
+ * 현재 시각이 서류 접수 기간 안인지 — 시작일 00:00 ~ 마감일 23:59:59.999 KST.
+ * `recruitingDates.documentSubmission`과 `recruitingApplicationSeasonYear`만 수정하면 버튼 분기가 따라갑니다.
+ */
+export function isRecruitingApplicationActive(now: Date = new Date()): boolean {
+  const year = recruitingApplicationSeasonYear;
+  const { month: openM, day: openD } = parseMonthDayFromRecruitingLabel(recruitingDates.documentSubmission.open);
+  const { month: dueM, day: dueD } = parseMonthDayFromRecruitingLabel(recruitingDates.documentSubmission.due);
+  const start = recruitingInstantKST(year, openM, openD, 0, 0, 0, 0);
+  const end = recruitingInstantKST(year, dueM, dueD, 23, 59, 59, 999);
+  const t = now.getTime();
+  return t >= start.getTime() && t <= end.getTime();
+}
 
 /** `11월 24일(월)` → `11월 24일` — 히어로 기간 문구 등에 사용 */
 export function recruitingDateWithoutWeekday(dayLabel: string): string {

--- a/apps/teampage/src/page/Recruiting-page/config.ts
+++ b/apps/teampage/src/page/Recruiting-page/config.ts
@@ -4,6 +4,7 @@
 
 export const recruitingAssets = {
   heroLogoBackground: '/img/recruit/logo.png',
+  angleBracket: '/img/recruit/anglebracket.svg',
 } as const;
 
 export const recruitingBrand = {
@@ -117,6 +118,223 @@ export const recruitingTargetAudience = {
 export const recruitingSectionTitles = {
   fields: { line1: '모집 분야 및', line2: '우대 사항' },
   schedule: '모집 일정',
+} as const;
+
+/** Section02 — Team / 시너자이즈 / 멘토 */
+export const recruitingSection02 = {
+  learnMoreHref: '/' as const,
+  learnMoreLabel: '시대생 자세히 알아보기',
+  teamHeading: 'Team UOSLIFE',
+  introParagraphs: [
+    'UOSLIFE(시대생)는 서울시립대학교 학우들에게 편리하고 즐거운 학교생활을 위한 서비스를 만들어가는 IT 소프트웨어 동아리입니다. 시대생 앱을 운영하며 시간표, 공지사항, 시대팅 등 대학 생활을 위한 다양한 서비스를 제공하고 있습니다.',
+    '2026년에는 대학 생활의 본질적 가치를 확장하는 새로운 기능과 경험을 선보이며, 학우들의 일상 속에 더욱 깊이 스며드는 플랫폼으로 성장할 것입니다. 아울러 구성원들이 자율적으로 협업하고 함께 배우는 문화를 바탕으로, 캠퍼스 내에서 지속 가능한 IT 생태계를 만들어 나가고자 합니다.',
+  ],
+  synergizeHeadingLine1: 'Synergize',
+  synergizeHeadingLine2: 'with Alumni',
+  synergizeParagraphs: [
+    '샌프란시스코 실리콘밸리의 성공 배경에는, Pay it forward라 불리는 IT 업계 선후배 사이의 멘토 문화가 핵심으로 자리 잡고 있습니다.',
+    '그리고 UOSLIFE는 업계 다방면에서 활동하는 선배들과 직접 소통하며 성장할 수 있는 곳입니다.',
+    "'UOSLIFE'는 5년 전 시작한 시대생 앱을 시작으로 선후배가 함께 어우러져 다양한 IT 서비스를 운영하고 있습니다.",
+  ],
+  mentors: [
+    { company: '네이버', name: '정인우', role: 'Back-end Engineer', src: '/img/recruit/mentor1.svg' },
+    { company: '카카오페이', name: '김나연', role: 'Back-end Engineer', src: '/img/recruit/mentor2.svg' },
+    { company: '미리디', name: '조종빈', role: 'Front-end Engineer', src: '/img/recruit/mentor3.svg' },
+    { company: 'SKT', name: '배서현', role: 'Infra Engineer', src: '/img/recruit/mentor4.svg' },
+    { company: '리멤버', name: '김은서', role: 'Product Manager', src: '/img/recruit/mentor5.svg' },
+    { company: 'PwC컨설팅', name: '문정민', role: 'Consultant', src: '/img/recruit/mentor6.svg' },
+    { company: '그릿스탠다드', name: '정희윤', role: 'UXUI Designer', src: '/img/recruit/mentor7.svg' },
+    { company: '에코마케팅', name: '우채윤', role: 'Marketer', src: '/img/recruit/mentor8.svg' },
+  ],
+} as const;
+
+/** Section03 — Alumni Network 로고 캐러셀 */
+export const recruitingSection03 = {
+  title: 'Alumni Network',
+  description:
+    '네이버, 카카오페이, 라인, 리멤버 등 국내 최고의 IT 회사부터 SKT, 현대자동차, NH투자증권, 한국은행 등 유수의 대기업/금융권까지',
+  descriptionContinued:
+    '다양한 업계의 구성원이 지속적인 시너지를 주고 받을 수 있는 관계를 만들어갑니다.',
+  logoSvgCount: 11,
+  carousel: {
+    desktop: { tilePx: 200, gapPx: 20, loopTiles: 9, durationSec: 20 },
+    mobileRow1: { tilePx: 120, gapPx: 12, loopTiles: 5, durationSec: 15 },
+    mobileRow2: { tilePx: 120, gapPx: 12, loopTiles: 4, durationSec: 15 },
+  },
+} as const;
+
+/** Section04 모집 분야 상세 블록 라벨 */
+export const recruitingFieldDetailLabels = {
+  responsibilitiesHeading: '하는 일',
+  partnerHeading: '이런 사람과 함께 하고 싶어요',
+} as const;
+
+export type RecruitingFieldWithItem = string | { readonly kind: 'bullet'; readonly text: string };
+
+export type RecruitingFieldSubRole = {
+  readonly subrole: string;
+  readonly do: readonly string[];
+  readonly with: readonly RecruitingFieldWithItem[];
+};
+
+export type RecruitingFieldRole =
+  | {
+      readonly role: string;
+      readonly type: 'one';
+      readonly do: readonly string[];
+      readonly with: readonly RecruitingFieldWithItem[];
+    }
+  | {
+      readonly role: string;
+      readonly type: 'two';
+      readonly content: readonly RecruitingFieldSubRole[];
+    };
+
+export const recruitingRoles: RecruitingFieldRole[] = [
+  {
+    role: '기획자',
+    type: 'one',
+    do: [
+      '기획 챕터는 프로덕트 출시 관련 계획, 일정 수립 등을 조직 차원에서 고민하고 결정해요.',
+      '우리가 개선해야 할 문제점은 무엇인지, 사용자에게 필요한 것이 무엇인지 고민하고 그에 맞는 해결 방법을 제시해요.',
+    ],
+    with: [
+      '사용자 관점에서 접근하고, 문제를 해결하기 위해 주도적으로 실행한 경험이 있으신 분',
+      '데이터를 수집하고 다각도에서 유저를 분석하는 것에 관심이 있으신 분',
+    ],
+  },
+  {
+    role: '디자이너',
+    type: 'one',
+    do: [
+      '디자인 챕터는 사용자가 우리 서비스를 재미있고 편하게 이용할 수 있도록 웹/앱을 설계하고, 직관적인 UI 경험을 만들어갑니다.',
+      '기획팀과 협업해 사용자의 불편을 직접 확인하고, 이를 해결할 수 있는 UI 아이디어를 고민하고 빠르게 시도합니다.',
+    ],
+    with: [
+      'Figma 또는 Adobe Illustrator 사용이 가능하신 분',
+      '‘내 취향’이 아닌 사용자가 원하는 것을 탐구하고 실험하시는 분',
+      '왜 이렇게 디자인했는지에 대한 논리와 근거를 바탕으로 작업하는 분',
+      '다양한 웹/앱 사례를 살펴보고 우리 서비스에 가장 적합한 UI를 찾아 적용하시는 분',
+    ],
+  },
+  {
+    role: '개발자',
+    type: 'two',
+    content: [
+      {
+        subrole: 'Front-End',
+        do: [
+          '사용자에게 가장 먼저 보이는 화면을 만들고, 더 나은 경험을 설계하는 일을 합니다.',
+          'React, TypeScript, Next.js 등 모던 자바스크립트 프레임워크·라이브러리을 통해 서비스를 구현합니다',
+          '디자인과 사용자 경험(UX)을 고려한 개발을 통해 ‘보이는 기술’을 만드는 팀입니다.',
+        ],
+        with: [
+          '새로운 기술을 배우는 걸 즐기고, 스스로 성장에 열정이 있는 분',
+          '코드뿐 아니라 사용자 경험(UX)에도 관심이 많은 분',
+          '완성도 높은 결과물을 위해 세세한 디테일을 놓치지 않는 분',
+          '아래 기술 스택에 익숙하신 분',
+          { kind: 'bullet', text: 'React (Vite) / Javascript(Typescript)' },
+        ],
+      },
+      {
+        subrole: 'Back-End',
+        do: [
+          '신규 기능을 설계 → 개발 → 배포까지 end-to-end로 경험해요.',
+          '현업 BE 선배들과 코드 리뷰/소통으로 함께 성장해요.',
+          '실제 운영 사례를 포트폴리오로 남길 수 있어요.',
+        ],
+        with: [
+          '비 개발자와도 커뮤니케이션이 원활하신 분',
+          '디자인 패턴, 아키텍처에 대해 고민해 본 경험이 있으면 좋아요.',
+          '아래 기술 스택에 익숙하신 분',
+          { kind: 'bullet', text: 'Kotlin(or Java) / Spring Boot / RDBMS(예: PostgreSQL, MySQL)' },
+        ],
+      },
+    ],
+  },
+  {
+    role: '마케터',
+    type: 'one',
+    do: [
+      '마케팅 챕터는 서비스의 가치를 알리고, 서비스의 Growth를 실현하는 역할을 맡고 있어요.',
+      'SNS, 팀 페이지의 콘텐츠 기획 및 운영을 통해 서비스 인지도와 브랜드 이미지를 강화해요.',
+      'CRM 활동(App Push 등)을 통해 유저의 재방문과 유지율을 높여요.',
+    ],
+    with: [
+      '온∙오프라인 마케팅 방안에 대한 다양한 아이디어와 실행 및 제작 능력이 있으신 분',
+      '유저 여정과 지표 분석에 관심이 많거나, 서비스 성장을 고민하고 싶은 분',
+    ],
+  },
+];
+
+/** `{기수}와 활동을 함께할 멘토` — Section02 */
+export function recruitingMentorSectionHeading(): string {
+  const cohort = recruitingBrand.cohortLabel.replace(/\s*모집\s*$/, '').trim();
+  return `${cohort}와 활동을 함께할 멘토`;
+}
+
+/** Section05 FAQ */
+export const recruitingFaqSectionTitle = '자주 묻는 질문';
+
+export const recruitingFaqItems: ReadonlyArray<{ question: string; answer: readonly string[] }> = [
+  {
+    question: 'Q. 시대생 앱은 어떻게 생겨 났나요?',
+    answer: [
+      '2020년 5월, 코로나19로 인한 서울시립대학교의 동문 단절로 인한 문제를 해결하고자 학부생 4명이 모여 시작했습니다.',
+      '비대면 수업 지원, 코로나 학번의 소통 단절, 동문 연결의 부재 등 서울시립대 내의 연결이 필요한 모든 영역을 IT 기술을 통해 해결하고 혁신하고자 했고, 그 결과 서울시립대의 대표 IT 프로덕트 시대생과 UOSLIFE 동아리가 탄생했습니다.',
+      'UOSLIFE는 IT 업계를 희망하는 재학생부터, 현직 주니어로 있는 졸업생들까지 서로의 고민을 공유하고 도우며 이제는 교내를 넘어 국내 IT 업계 최고의 엘리트 공동체로 성장하고자 하는 비전을 갖고 있습니다.',
+    ],
+  },
+  {
+    question: 'Q. 정기 모임은 언제, 어디서 하나요?',
+    answer: [
+      'UOSLIFE는 격주 목요일 저녁 7시 30분에 정기 팀 회의를 진행하고 있습니다. 팀 회의는 각 TF의 활동 공유&친목 도모를 위해 진행되며 가벼운 뒤풀이가 있을 수 있습니다.',
+      '매 방학 시즌에는 신규 기능 개발 프로젝트를 진행하며, 이 경우 격주 토요일에 전일(10AM.-10PM.)으로 모여 코어 타임을 갖고 있습니다. 이번 겨울 프로젝트는 1/3(토)를 기점으로 진행될 예정입니다.',
+      '*모든 모임은 오프라인 대면으로 진행되고 있으며 프로젝트 상황에 따라 달라질 수 있습니다.',
+    ],
+  },
+  {
+    question: 'Q. 졸업생도 지원이 가능한가요?',
+    answer: [
+      '1년간 꾸준히 활동할 수 있고 배우고자 하는 열의가 충분하다면, 누구든 지원이 가능합니다. 현재도 재학생, 휴학생, 졸업생 중 활발히 활동하시는 분들이 계십니다.',
+      '하지만, 매월 둘째 주, 넷째 주에 진행하는 정기 회의 (목요일 7시 30분)와 방학 기간 동안의 *프로젝트 코어 타임은 반드시 참여해야 한다는 점은 꼭 숙지해 주세요!',
+      '*프로젝트 코어 타임: 1월 3일부터 격주 토요일 전일',
+    ],
+  },
+  {
+    question: 'Q. 실력이 뛰어난 사람만 지원할 수 있나요?',
+    answer: [
+      'UOSLIFE에서는 1년간 꾸준히 활동할 수 있는지, 그리고 성장하고자 하는 의지가 충분한지를 가장 중요하게 생각합니다.',
+      '그러나 교육보다는 프로젝트 진행 중심이기에 내부 현직 특강, 기초 교육 외에는 별도의 체계적인 교육 커리큘럼을 진행하고 있지 않습니다. 따라서, 동아리 활동 외에도 개인적인 노력이 함께 되어야 함을 알아주시길 바랍니다.',
+    ],
+  },
+  {
+    question: 'Q. UOSLIFE Alummi (졸업생 및 동문)도 함께 활동하나요?',
+    answer: [
+      '네, 함께 활동합니다. 학기에 따라 다르지만 UOSLIFE 동아리를 졸업한 Alumni들도 지속적으로 활동하고 있습니다.',
+      '방학 프로젝트 및 현직자 특강 등을 통해 재학생들의 성장을 지원하고, 내부 네트워킹 및 현직자 모임을 통해 지속적으로 교류하고 있습니다.',
+    ],
+  },
+];
+
+/** Section06 — 모집 종료 안내 */
+export const recruitingSection06 = {
+  headlineLine1: '모집 기간이',
+  headlineLine2: '종료되었어요',
+  description: '다음 모집 알림을 받으면 빠르게 지원할 수 있어요!',
+} as const;
+
+/** Section07 — 문의 카드 */
+export const recruitingSection07 = {
+  headlineLine1: '더 궁금한 게 있다면',
+  headlineLine2: '아래를 통해 문의해 주세요',
+  kakaoHref: 'https://pf.kakao.com/_gMEHK',
+  kakaoCardTitleSuffix: '에 궁금한 점이나 의견이 있다면?',
+  kakaoCardLinkLabel: '시대생 카카오톡 채널 바로가기',
+  instagramHref: 'https://www.instagram.com/uoslife_official/',
+  instagramCardTitleSuffix: '의 실시간 소식을 알고 싶다면?',
+  instagramCardLinkLabel: '시대생 인스타그램 바로가기',
+  brandAccentName: 'UOSLIFE',
 } as const;
 
 export type RecruitingScheduleEntry =

--- a/apps/teampage/src/page/Recruiting-page/section/Recruitbutton.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Recruitbutton.tsx
@@ -1,17 +1,20 @@
-import { ISINRANGE } from '../Recruitingpage';
+import {
+  isRecruitingApplicationActive,
+  recruitingApplyButtonLabel,
+  recruitingCallToAction,
+} from '@/page/Recruiting-page/config';
 import { useAnalytics } from '@/entities/analytics/useAnalytics';
 
 export function Recruitbutton({ className = '' }) {
   const { trackEvent } = useAnalytics();
-  const status = false ? '6기 지원하기' : '다음 모집 알림 받기';
+  const applicationActive = isRecruitingApplicationActive();
+  const label = applicationActive ? recruitingApplyButtonLabel() : recruitingCallToAction.notifyLabel;
   return (
     <button
       onClick={() => {
         trackEvent('CLICK_RECRUIT_BUTTON', undefined);
         window.open(
-          ISINRANGE
-            ? 'https://docs.google.com/forms/d/e/1FAIpQLSeBv_mC-gD4WdQAbYZ6RPHDmuiHLey44AaU5XBeDgxLkSqcKQ/viewform'
-            : 'http://forms.gle/JntWWCzKjzRwZbaJ7',
+          applicationActive ? recruitingCallToAction.applyFormUrl : recruitingCallToAction.notifyFormUrl,
           '_blank',
         );
       }}
@@ -19,7 +22,7 @@ export function Recruitbutton({ className = '' }) {
       max-md:h-12 max-md:px-7 max-md:rounded-lg`}
     >
       <span className="text-white text-2xl font-bold leading-[150%] max-md:text-base max-md:leading-[160%]">
-        {status}
+        {label}
       </span>
     </button>
   );

--- a/apps/teampage/src/page/Recruiting-page/section/RecruitmentField.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/RecruitmentField.tsx
@@ -1,14 +1,30 @@
 'use client';
 
-import React from 'react';
 import { useState } from 'react';
+
+import {
+  recruitingFieldDetailLabels,
+  recruitingRoles,
+  type RecruitingFieldRole,
+  type RecruitingFieldSubRole,
+  type RecruitingFieldWithItem,
+} from '@/page/Recruiting-page/config';
+
 import { RecruitmentFieldButton } from './RecruitmentFieldButton';
 
-const Detail = ({ item }) => {
+function Detail({
+  item,
+}: {
+  item: {
+    readonly do: readonly string[];
+    readonly with: readonly RecruitingFieldWithItem[];
+  };
+}) {
+  const labels = recruitingFieldDetailLabels;
   return (
     <>
       <div className="flex flex-col items-start gap-4 self-stretch">
-        <h6 className="text-[#222227] text-xl font-bold leading-[160%] max-md:text-sm">하는 일</h6>
+        <h6 className="text-[#222227] text-xl font-bold leading-[160%] max-md:text-sm">{labels.responsibilitiesHeading}</h6>
         <ul className="self-stretch text-[#303037] text-lg font-medium leading-[160%] list-disc pl-5 space-y-2 [&>li]:pl-2 max-md:text-sm">
           {item.do.map((task, taskIndex) => (
             <li key={taskIndex}>{task}</li>
@@ -16,122 +32,25 @@ const Detail = ({ item }) => {
         </ul>
       </div>
       <div className="flex flex-col items-start gap-4 self-stretch">
-        <h6 className="text-[#222227] text-xl font-bold leading-[160%] max-md:text-sm">이런 사람과 함께 하고 싶어요</h6>
-        <ul
-          className="self-stretch text-[#303037] text-lg font-medium leading-[160%] list-disc pl-5 space-y-2 [&>li]:pl-2 
-        max-md:text-sm"
-        >
+        <h6 className="text-[#222227] text-xl font-bold leading-[160%] max-md:text-sm">{labels.partnerHeading}</h6>
+        <ul className="self-stretch text-[#303037] text-lg font-medium leading-[160%] list-disc pl-5 space-y-2 [&>li]:pl-2 max-md:text-sm">
           {item.with.map((requirement, reqIndex) => {
-            if (React.isValidElement(requirement)) {
-              return (
-                <li key={reqIndex} className="list-none pl-0">
-                  {requirement}
-                </li>
-              );
+            if (typeof requirement === 'string') {
+              return <li key={reqIndex}>{requirement}</li>;
             }
-            return <li key={reqIndex}>{requirement}</li>;
+            return (
+              <li key={reqIndex} className="list-disc">
+                {requirement.text}
+              </li>
+            );
           })}
         </ul>
       </div>
     </>
   );
-};
-interface SubRole {
-  subrole: string;
-  do: string[];
-  with: (string | React.ReactNode)[];
 }
 
-interface textRole {
-  role: string;
-  type: string;
-  do?: string[];
-  with?: string[];
-  content?: SubRole[];
-}
-
-const Section4text: textRole[] = [
-  {
-    role: '기획자',
-    type: 'one',
-    do: [
-      '기획 챕터는 프로덕트 출시 관련 계획, 일정 수립 등을 조직 차원에서 고민하고 결정해요.',
-      '우리가 개선해야 할 문제점은 무엇인지, 사용자에게 필요한 것이 무엇인지 고민하고 그에 맞는 해결 방법을 제시해요.',
-    ],
-    with: [
-      '사용자 관점에서 접근하고, 문제를 해결하기 위해 주도적으로 실행한 경험이 있으신 분',
-      '데이터를 수집하고 다각도에서 유저를 분석하는 것에 관심이 있으신 분',
-    ],
-  },
-  {
-    role: '디자이너',
-    type: 'one',
-    do: [
-      '디자인 챕터는 사용자가 우리 서비스를 재미있고 편하게 이용할 수 있도록 웹/앱을 설계하고, 직관적인 UI 경험을 만들어갑니다.',
-      '기획팀과 협업해 사용자의 불편을 직접 확인하고, 이를 해결할 수 있는 UI 아이디어를 고민하고 빠르게 시도합니다.',
-    ],
-    with: [
-      'Figma 또는 Adobe Illustrator 사용이 가능하신 분',
-      '‘내 취향’이 아닌 사용자가 원하는 것을 탐구하고 실험하시는 분',
-      '왜 이렇게 디자인했는지에 대한 논리와 근거를 바탕으로 작업하는 분',
-      '다양한 웹/앱 사례를 살펴보고 우리 서비스에 가장 적합한 UI를 찾아 적용하시는 분',
-    ],
-  },
-  {
-    role: '개발자',
-    type: 'two',
-    content: [
-      {
-        subrole: 'Front-End',
-        do: [
-          '사용자에게 가장 먼저 보이는 화면을 만들고, 더 나은 경험을 설계하는 일을 합니다.',
-          'React, TypeScript, Next.js 등 모던 자바스크립트 프레임워크·라이브러리을 통해 서비스를 구현합니다',
-          '디자인과 사용자 경험(UX)을 고려한 개발을 통해 ‘보이는 기술’을 만드는 팀입니다.',
-        ],
-        with: [
-          '새로운 기술을 배우는 걸 즐기고, 스스로 성장에 열정이 있는 분',
-          '코드뿐 아니라 사용자 경험(UX)에도 관심이 많은 분',
-          '완성도 높은 결과물을 위해 세세한 디테일을 놓치지 않는 분',
-          '아래 기술 스택에 익숙하신 분',
-          <li key="dveloper-width" className="list-disc">
-            React (Vite) / Javascript(Typescript)
-          </li>,
-        ],
-      },
-      {
-        subrole: 'Back-End',
-        do: [
-          '신규 기능을 설계 → 개발 → 배포까지 end-to-end로 경험해요.',
-          '현업 BE 선배들과 코드 리뷰/소통으로 함께 성장해요.',
-          '실제 운영 사례를 포트폴리오로 남길 수 있어요.',
-        ],
-        with: [
-          '비 개발자와도 커뮤니케이션이 원활하신 분',
-          '디자인 패턴, 아키텍처에 대해 고민해 본 경험이 있으면 좋아요.',
-          '아래 기술 스택에 익숙하신 분',
-          <li key="subrole-width" className="list-disc">
-            Kotlin(or Java) / Spring Boot / RDBMS(예: PostgreSQL, MySQL)
-          </li>,
-        ],
-      },
-    ],
-  },
-  {
-    role: '마케터',
-    type: 'one',
-    do: [
-      '마케팅 챕터는 서비스의 가치를 알리고, 서비스의 Growth를 실현하는 역할을 맡고 있어요.',
-      'SNS, 팀 페이지의 콘텐츠 기획 및 운영을 통해 서비스 인지도와 브랜드 이미지를 강화해요.',
-      'CRM 활동(App Push 등)을 통해 유저의 재방문과 유지율을 높여요.',
-    ],
-    with: [
-      '온∙오프라인 마케팅 방안에 대한 다양한 아이디어와 실행 및 제작 능력이 있으신 분',
-      '유저 여정과 지표 분석에 관심이 많거나, 서비스 성장을 고민하고 싶은 분',
-    ],
-  },
-];
-
-export const FnQContent = ({ item, index }: { item: textRole; index: number }) => {
+export const FnQContent = ({ item, index }: { item: RecruitingFieldRole; index: number }) => {
   const initS = index === 0 ? true : false;
   const [isOpen, setIsOpen] = useState(initS);
   return (
@@ -145,7 +64,6 @@ export const FnQContent = ({ item, index }: { item: textRole; index: number }) =
         className="flex flex-col items-start gap-5 self-stretch
             max-md: gap-4"
       >
-
         <RecruitmentFieldButton name={item.role} open={isOpen} setOpen={setIsOpen} />
         {isOpen && (
           <>
@@ -153,10 +71,10 @@ export const FnQContent = ({ item, index }: { item: textRole; index: number }) =
             {item.type == 'one' ? (
               <Detail item={item} />
             ) : (
-              item.content?.map((subitem, subIndex) => (
+              item.content?.map((subitem: RecruitingFieldSubRole, subIndex: number) => (
                 <div key={subIndex} className="flex flex-col items-start gap-5 self-stretch max-md: gap-2">
                   <h5 className="text-[#222227] text-2xl font-bold leading-[150%]">{subitem.subrole}</h5>
-                  <Detail item={subitem}></Detail>
+                  <Detail item={subitem} />
                 </div>
               ))
             )}
@@ -170,7 +88,7 @@ export const FnQContent = ({ item, index }: { item: textRole; index: number }) =
 export function RecruitmentField() {
   return (
     <>
-      {Section4text.map((item, index) => (
+      {recruitingRoles.map((item, index) => (
         <FnQContent key={index} item={item} index={index} />
       ))}
     </>

--- a/apps/teampage/src/page/Recruiting-page/section/Section01.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section01.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Text } from '@/shared/component/Text';
-import React from 'react';
+import { recruitingAssets, recruitingBrand, recruitingPeriod } from '@/page/Recruiting-page/config';
 
 export function Section01() {
   return (
@@ -16,19 +16,19 @@ const DesktopView = () => {
   return (
     <div
       className="hidden md:flex justify-center items-center bg-center bg-no-repeat bg-cover min-h-screen"
-      style={{ backgroundImage: "url('/img/recruit/logo.png')" }}
+      style={{ backgroundImage: `url('${recruitingAssets.heroLogoBackground}')` }}
     >
       <div className="flex flex-col w-[1280px] gap-8 text-left">
-        <p className="w-fit text-[220px] font-bold leading-[100%] tracking-[-4.4px] text-[#222227]">UOSLIFE</p>
+        <p className="w-fit text-[220px] font-bold leading-[100%] tracking-[-4.4px] text-[#222227]">{recruitingBrand.name}</p>
         <div className="flex justify-between">
           <div className="flex flex-col gap-2 text-[18px] font-medium text-[#222227] justify-end">
             <div className="flex items-center gap-3">
-              <p>11월 24일부터</p>
+              <p>{recruitingPeriod.rangeStartLabel}</p>
               <span className="inline-block h-[2px] w-[45px] bg-[#222227]" />
             </div>
-            <p>11월 30일까지</p>
+            <p>{recruitingPeriod.rangeEndLabel}</p>
           </div>
-          <p className="w-fit text-[220px] font-bold leading-[100%] tracking-[-4.4px] text-[#222227]">6기 모집</p>
+          <p className="w-fit text-[220px] font-bold leading-[100%] tracking-[-4.4px] text-[#222227]">{recruitingBrand.cohortLabel}</p>
         </div>
       </div>
     </div>
@@ -40,24 +40,24 @@ const MobileView = () => {
     <div className="flex md:hidden flex-col gap-7">
       <div
         className="flex pt-8 justify-center items-center bg-center bg-no-repeat bg-cover"
-        style={{ backgroundImage: "url('/img/recruit/logo.png')" }}
+        style={{ backgroundImage: `url('${recruitingAssets.heroLogoBackground}')` }}
       >
         <div className="flex flex-col items-center">
           <Text variant="heading-80-b" color="grey-900">
-            UOSLIFE
+            {recruitingBrand.name}
           </Text>
           <Text variant="heading-80-b" color="grey-900">
-            6기 모집
+            {recruitingBrand.cohortLabel}
           </Text>
         </div>
       </div>
       <div className="flex items-center justify-center gap-3">
         <Text variant="title-18-b" color="grey-900">
-          11월 24일부터
+          {recruitingPeriod.rangeStartLabel}
         </Text>
         <span className="inline-block h-[2px] w-[45px] bg-[#222227]" />
         <Text variant="title-18-b" color="grey-900">
-          11월 30일까지
+          {recruitingPeriod.rangeEndLabel}
         </Text>
       </div>
     </div>

--- a/apps/teampage/src/page/Recruiting-page/section/Section02.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section02.tsx
@@ -127,7 +127,7 @@ export function Section02() {
 
         <div className="flex w-2/3 flex-col items-center gap-[60px] md:mx-auto pb-40 max-md:gap-[24px] max-md:px-[16px] max-md:w-[100%] max-md:pb-[60px]">
           <h2
-            className="text-[40px] text-center leading-[140%] font-bold text-[#222227] max-md:leading-[160%] max-md:text-[20px]
+            className="text-[40px] text-center leading-[140%] font-bold text-[#222227] max-md:text-[20px]
         max-md:leading-[160%]"
           >
             6기와 활동을 함께할 멘토
@@ -136,7 +136,7 @@ export function Section02() {
             {People.map((person, idx) => (
               <div
                 key={idx}
-                className="flex flex-col items-center rounded-2xl bg-white py-6 px-9 shadow-md justify-center items-center gap-7 rounded-[20px] border-[1.5px] border-white bg-white shadow-[0_0_16px_0_rgba(70,134,255,0.12)] max-md:py-[12px] max-md:px-[24px] max-md:gap-[12px]"
+                className="flex flex-col rounded-2xl py-6 px-9 justify-center items-center gap-7 border-[1.5px] border-white shadow-[0_0_16px_0_rgba(70,134,255,0.12)] max-md:py-[12px] max-md:px-[24px] max-md:gap-[12px]"
               >
                 <Image
                   src={person.src}

--- a/apps/teampage/src/page/Recruiting-page/section/Section02.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section02.tsx
@@ -2,65 +2,15 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { twMerge } from 'tailwind-merge';
 
-type People = {
-  company: string;
-  name: string;
-  role: string;
-  src: string;
-};
-
-const People = [
-  {
-    company: '네이버',
-    name: '정인우',
-    role: 'Back-end Engineer',
-    src: '/img/recruit/mentor1.svg',
-  },
-  {
-    company: '카카오페이',
-    name: '김나연',
-    role: 'Back-end Engineer',
-    src: '/img/recruit/mentor2.svg',
-  },
-  {
-    company: '미리디',
-    name: '조종빈',
-    role: 'Front-end Engineer',
-    src: '/img/recruit/mentor3.svg',
-  },
-  {
-    company: 'SKT',
-    name: '배서현',
-    role: 'Infra Engineer',
-    src: '/img/recruit/mentor4.svg',
-  },
-  {
-    company: '리멤버',
-    name: '김은서',
-    role: 'Product Manager',
-    src: '/img/recruit/mentor5.svg',
-  },
-  {
-    company: 'PwC컨설팅',
-    name: '문정민',
-    role: 'Consultant',
-    src: '/img/recruit/mentor6.svg',
-  },
-  {
-    company: '그릿스탠다드',
-    name: '정희윤',
-    role: 'UXUI Designer',
-    src: '/img/recruit/mentor7.svg',
-  },
-  {
-    company: '에코마케팅',
-    name: '우채윤',
-    role: 'Marketer',
-    src: '/img/recruit/mentor8.svg',
-  },
-] as const satisfies People[];
+import {
+  recruitingAssets,
+  recruitingMentorSectionHeading,
+  recruitingSection02,
+} from '@/page/Recruiting-page/config';
 
 export function Section02() {
+  const { mentors } = recruitingSection02;
+
   return (
     <>
       <div
@@ -73,26 +23,24 @@ export function Section02() {
             className="whitespace-nowrap font-['Pretendard'] text-[48px] font-bold leading-[140%] self-stretch bg-gradient-to-r from-black via-[#0F6EFB] to-[#AACEFF] bg-clip-text text-transparent 
           max-md:text-[24px] max-md:leading-[150%]"
           >
-            Team UOSLIFE
+            {recruitingSection02.teamHeading}
           </h2>
-          <Link href="/" className="flex p-1 items-center gap-1">
-            시대생 자세히 알아보기
+          <Link href={recruitingSection02.learnMoreHref} className="flex p-1 items-center gap-1">
+            {recruitingSection02.learnMoreLabel}
             <div className="text-[#54545C] font-['Pretendard'] text-xl font-medium leading-[160%] max-md:text-[14px]">
-              <Image src="/img/recruit/anglebracket.svg" alt="bracket" width={8} height={8} />
+              <Image src={recruitingAssets.angleBracket} alt="bracket" width={8} height={8} />
             </div>
           </Link>
         </div>
         <div className="text-[#303037] font-['Pretendard'] text-xl font-medium leading-[160%] gap-5 flex flex-col">
-          <p className="text-[#303037] font-['Pretendard'] text-xl font-medium leading-[160%] max-md:text-[14px]">
-            UOSLIFE(시대생)는 서울시립대학교 학우들에게 편리하고 즐거운 학교생활을 위한 서비스를 만들어가는 IT
-            소프트웨어 동아리입니다. 시대생 앱을 운영하며 시간표, 공지사항, 시대팅 등 대학 생활을 위한 다양한 서비스를
-            제공하고 있습니다.
-          </p>
-          <p className="text-[#303037] font-['Pretendard'] text-xl font-medium leading-[160%] max-md:text-[14px]">
-            2026년에는 대학 생활의 본질적 가치를 확장하는 새로운 기능과 경험을 선보이며, 학우들의 일상 속에 더욱 깊이
-            스며드는 플랫폼으로 성장할 것입니다. 아울러 구성원들이 자율적으로 협업하고 함께 배우는 문화를 바탕으로,
-            캠퍼스 내에서 지속 가능한 IT 생태계를 만들어 나가고자 합니다.
-          </p>
+          {recruitingSection02.introParagraphs.map((paragraph, idx) => (
+            <p
+              key={idx}
+              className="text-[#303037] font-['Pretendard'] text-xl font-medium leading-[160%] max-md:text-[14px]"
+            >
+              {paragraph}
+            </p>
+          ))}
         </div>
       </div>
       <div
@@ -107,21 +55,18 @@ export function Section02() {
           )}
         >
           <h2 className="text-[#222227] text-center font-['Pretendard'] text-[72px] font-bold leading-[120%] max-md:text-[32px] max-md:leading-[140%]">
-            Synergize <br className="md:hidden" />
-            with Alumni
+            {recruitingSection02.synergizeHeadingLine1} <br className="md:hidden" />
+            {recruitingSection02.synergizeHeadingLine2}
           </h2>
           <div className="w-2/3 max-md:w-[100%]">
-            <p className="text-[#303037] text-center font-['Pretendard'] text-xl font-medium leading-[160%] self-stretch max-md:text-[14px]">
-              샌프란시스코 실리콘밸리의 성공 배경에는, Pay it forward라 불리는 IT 업계 선후배 사이의 멘토 문화가
-              핵심으로 자리 잡고 있습니다.
-            </p>
-            <p className="text-[#303037] text-center font-['Pretendard'] text-xl font-medium leading-[160%] self-stretch max-md:text-[14px]">
-              그리고 UOSLIFE는 업계 다방면에서 활동하는 선배들과 직접 소통하며 성장할 수 있는 곳입니다.
-            </p>
-            <p className="text-[#303037] text-center font-['Pretendard'] text-xl font-medium leading-[160%] self-stretch max-md:text-[14px]">
-              &apos;UOSLIFE&apos;는 5년 전 시작한 시대생 앱을 시작으로 선후배가 함께 어우러져 다양한 IT 서비스를
-              운영하고 있습니다.
-            </p>
+            {recruitingSection02.synergizeParagraphs.map((line, idx) => (
+              <p
+                key={idx}
+                className="text-[#303037] text-center font-['Pretendard'] text-xl font-medium leading-[160%] self-stretch max-md:text-[14px]"
+              >
+                {line}
+              </p>
+            ))}
           </div>
         </div>
 
@@ -130,10 +75,10 @@ export function Section02() {
             className="text-[40px] text-center leading-[140%] font-bold text-[#222227] max-md:text-[20px]
         max-md:leading-[160%]"
           >
-            6기와 활동을 함께할 멘토
+            {recruitingMentorSectionHeading()}
           </h2>
           <div className="grid w-full grid-cols-2 gap-[20px] lg:grid-cols-4">
-            {People.map((person, idx) => (
+            {mentors.map((person, idx) => (
               <div
                 key={idx}
                 className="flex flex-col rounded-2xl py-6 px-9 justify-center items-center gap-7 border-[1.5px] border-white shadow-[0_0_16px_0_rgba(70,134,255,0.12)] max-md:py-[12px] max-md:px-[24px] max-md:gap-[12px]"

--- a/apps/teampage/src/page/Recruiting-page/section/Section02.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section02.tsx
@@ -65,7 +65,7 @@ export function Section02() {
     <>
       <div
         className={twMerge(
-          'flex items-start w-[100%] flex-row gap-[13.25rem] pb-60 px-80 pt-[100px] max-lg:flex-col max-lg:px-[16px] max-lg:gap-7 max-lg:w-[100%] max-lg:justify-center max-lg:pt-[80px] max-lg:pb-[120px]',
+          'flex items-start w-[100%] flex-row gap-[13.25rem] pb-60 px-20 pt-[100px] max-lg:flex-col max-lg:px-[16px] max-lg:gap-7 max-lg:w-[100%] max-lg:justify-center max-lg:pt-[80px] max-lg:pb-[120px]',
         )}
       >
         <div className="flex flex-col items-start gap-5">
@@ -125,7 +125,7 @@ export function Section02() {
           </div>
         </div>
 
-        <div className="flex w-2/3 flex-col items-center gap-[60px]  md:mx-auto pb-40 max-md:gap-[24px] max-md:px-[16px] max-md:w-[100%] max-md:pb-[60px]">
+        <div className="flex w-2/3 flex-col items-center gap-[60px] md:mx-auto pb-40 max-md:gap-[24px] max-md:px-[16px] max-md:w-[100%] max-md:pb-[60px]">
           <h2
             className="text-[40px] text-center leading-[140%] font-bold text-[#222227] max-md:leading-[160%] max-md:text-[20px]
         max-md:leading-[160%]"

--- a/apps/teampage/src/page/Recruiting-page/section/Section03.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section03.tsx
@@ -1,12 +1,22 @@
 import Image from 'next/image';
 import { twMerge } from 'tailwind-merge';
 
-export function Section03() {
-  const logos = Array.from({ length: 11 }, (_, i) => `/svg/logo/${i + 1}.svg`);
+import { recruitingSection03 } from '@/page/Recruiting-page/config';
 
-  // 모바일용 2줄 분할
-  const firstRow = logos.slice(0, 6); // 5개
-  const secondRow = logos.slice(6); // 4개
+export function Section03() {
+  const { logoSvgCount, carousel } = recruitingSection03;
+  const logos = Array.from({ length: logoSvgCount }, (_, i) => `/svg/logo/${i + 1}.svg`);
+
+  const firstRow = logos.slice(0, 6);
+  const secondRow = logos.slice(6);
+
+  const desk = carousel.desktop;
+  const r1 = carousel.mobileRow1;
+  const r2 = carousel.mobileRow2;
+
+  const desktopTranslate = `calc((-${desk.tilePx}px - ${desk.gapPx}px) * ${desk.loopTiles})`;
+  const mobileRow1Translate = `calc((-${r1.tilePx}px - ${r1.gapPx}px) * ${r1.loopTiles})`;
+  const mobileRow2Start = `calc((-${r2.tilePx}px - ${r2.gapPx}px) * ${r2.loopTiles})`;
 
   return (
     <div
@@ -15,26 +25,23 @@ export function Section03() {
       )}
     >
       <div className="flex flex-col items-center gap-8 self-stretch max-md:gap-[12px]">
-        {/* 제목 */}
         <h2
           className="text-[#222227] text-center font-['Pretendard'] text-[40px] font-bold leading-[140%]
-         max-md:text-[20px] max-md:leading-[160%]        
+          max-md:text-[20px] max-md:leading-[160%]        
         "
         >
-          Alumni Network
+          {recruitingSection03.title}
         </h2>
         <p
           className="text-[#303037] text-center font-['Pretendard'] text-xl font-medium leading-[160%] max-md:text-[14px] max-md:px-4
         "
         >
-          네이버, 카카오페이, 라인, 리멤버 등 국내 최고의 IT 회사부터 SKT, 현대자동차, NH투자증권, 한국은행 등 유수의
-          대기업/금융권까지
+          {recruitingSection03.description}
           <br className="hidden lg:block" />
-          다양한 업계의 구성원이 지속적인 시너지를 주고 받을 수 있는 관계를 만들어갑니다.
+          {recruitingSection03.descriptionContinued}
         </p>
       </div>
 
-      {/* 데스크톱: 1줄 캐러셀 (왼쪽으로 이동) */}
       <div className="relative w-full overflow-hidden max-md:hidden">
         <div className="carousel-track flex gap-[20px]">
           {[...logos, ...logos].map((src, idx) => (
@@ -49,9 +56,7 @@ export function Section03() {
         </div>
       </div>
 
-      {/* 모바일: 2줄 캐러셀 (반대 방향) */}
       <div className="relative w-full overflow-hidden md:hidden flex flex-col gap-[12px]">
-        {/* 첫 번째 줄 (왼쪽으로 이동) */}
         <div className="carousel-track-left flex gap-[12px]">
           {[...firstRow, ...firstRow].map((src, idx) => (
             <div
@@ -64,7 +69,6 @@ export function Section03() {
           ))}
         </div>
 
-        {/* 두 번째 줄 (오른쪽으로 이동) */}
         <div className="carousel-track-right flex gap-[12px]">
           {[...secondRow, ...secondRow].map((src, idx) => (
             <div
@@ -84,7 +88,7 @@ export function Section03() {
             transform: translateX(0);
           }
           100% {
-            transform: translateX(calc((-200px - 20px) * 9));
+            transform: translateX(${desktopTranslate});
           }
         }
 
@@ -93,13 +97,13 @@ export function Section03() {
             transform: translateX(0);
           }
           100% {
-            transform: translateX(calc((-120px - 12px) * 5));
+            transform: translateX(${mobileRow1Translate});
           }
         }
 
         @keyframes scroll-right-mobile-second {
           0% {
-            transform: translateX(calc((-120px - 12px) * 4));
+            transform: translateX(${mobileRow2Start});
           }
           100% {
             transform: translateX(0);
@@ -107,17 +111,17 @@ export function Section03() {
         }
 
         .carousel-track {
-          animation: scroll-left 20s linear infinite;
+          animation: scroll-left ${desk.durationSec}s linear infinite;
           will-change: transform;
         }
 
         .carousel-track-left {
-          animation: scroll-left-mobile-first 15s linear infinite;
+          animation: scroll-left-mobile-first ${r1.durationSec}s linear infinite;
           will-change: transform;
         }
 
         .carousel-track-right {
-          animation: scroll-right-mobile-second 15s linear infinite;
+          animation: scroll-right-mobile-second ${r2.durationSec}s linear infinite;
           will-change: transform;
         }
       `}</style>

--- a/apps/teampage/src/page/Recruiting-page/section/Section04.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section04.tsx
@@ -1,6 +1,83 @@
 'use client';
 
+import { Fragment } from 'react';
+
+import {
+  recruitingHeadline,
+  recruitingSchedule,
+  recruitingSectionTitles,
+  recruitingTargetAudience,
+  type RecruitingScheduleEntry,
+} from '@/page/Recruiting-page/config';
+
 import { RecruitmentField } from './RecruitmentField';
+
+function ScheduleDivider() {
+  return (
+    <svg className="w-full h-px self-stretch" preserveAspectRatio="none">
+      <rect width="100%" height="1" fill="rgba(70, 134, 255, 0.20)" />
+    </svg>
+  );
+}
+
+function ScheduleRow({ entry }: { entry: RecruitingScheduleEntry }) {
+  const titleClass =
+    'text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]';
+  const dateClass =
+    'text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base';
+  const footnoteClass =
+    'text-[#80808B] text-base font-medium leading-[160%] max-md:self-stretch max-md:text-xs max-md:leading-[150%] max-2xl:text-sm';
+
+  if (entry.kind === 'documentSubmission') {
+    return (
+      <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
+        <h5 className={titleClass}>{entry.title}</h5>
+        <div className="flex items-start gap-3 pt-0.5 max-md:gap-2">
+          <div className="flex items-center gap-3 max-md:gap-2">
+            <p className={dateClass}>{entry.openDate}</p>
+            <div className="w-10 h-0.5 bg-[#222227] max-md:h-px" />
+          </div>
+          <div className="flex flex-col items-start gap-0.5 max-md:w-[7.2rem]">
+            <p className={dateClass}>{entry.dueDate}</p>
+            <p className={dateClass}>{entry.dueTimeNote}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (entry.kind === 'singleDay') {
+    return (
+      <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
+        <h5 className={titleClass}>{entry.title}</h5>
+        {entry.footnote ? (
+          <div className="flex flex-col items-start w-[7.75rem] pt-0.5 gap-4 max-md:w-[4.6875rem] max-md:gap-3">
+            <p className={dateClass}>{entry.date}</p>
+            <p className={`${footnoteClass} max-md:text-xs max-md:leading-[150%]`}>{entry.footnote}</p>
+          </div>
+        ) : (
+          <p className={`${dateClass} max-md:self-stretch`}>{entry.date}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
+      <h5 className={titleClass}>{entry.title}</h5>
+      <div className="flex flex-col items-start pt-0.5 gap-4 max-md:gap-3">
+        <div className="flex items-center gap-3 self-stretch max-md:gap-2">
+          <p className={dateClass}>{entry.startDate}</p>
+          <div className="w-10 h-0.5 bg-[#222227] max-md:h-px" />
+          <p className={dateClass}>{entry.endDate}</p>
+        </div>
+        {entry.footnote ? (
+          <p className={`${footnoteClass} max-md:text-xs max-md:leading-[150%]`}>{entry.footnote}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
 
 export function Section04() {
   return (
@@ -12,10 +89,15 @@ export function Section04() {
         className="self-stretch text-[#222227] font-bold text-[4.5rem] leading-[120%]  w-full max-md:text-[2rem] 
       max-md:leading-[140%] max-lg:text-[3rem]"
       >
-        IT 기술을 통해 <br />
-        서울시립대학교 구성원을 <br />
-        연결하는 프로덕트를 <br />
-        만들어갈 인재를 <br className="md:hidden" /> 모집합니다.
+        {recruitingHeadline.lines.map((line) => (
+          <Fragment key={line}>
+            {line}
+            <br />
+          </Fragment>
+        ))}
+        {recruitingHeadline.lastLinePrefix}
+        <br className="md:hidden" />
+        {recruitingHeadline.lastLineSuffix}
       </h3>
       <div className="flex flex-col items-start self-stretch gap-[120px] max-md:gap-11">
         <div
@@ -23,25 +105,26 @@ export function Section04() {
         max-xl:w-[48rem]"
         >
           <h4 className="text-[#222227] font-bold text-[2.5rem] leading-[140%] max-md:self-stretch max-md:text-xl max-md:leading-[160%]">
-            모집 대상
+            {recruitingTargetAudience.sectionTitle}
           </h4>
           <div className="flex pt-1 flex-col items-start gap-5 max-md:gap-3 max-md:self-stretch">
             <div className="flex flex-col items-start gap-1 self-stretch max-md:gap-0.5 max-md:self-stretch">
               <p className="text-grey-900 font-bold text-xl leading-loose not-italic max-md:text-sm max-md:leading-[160%] max-md:self-stretch">
-                IT 서비스에 관심 있는 서울시립대학교 재학생 및 졸업생
+                {recruitingTargetAudience.primaryTitle}
               </p>
               <p className="self-stretch text-grey-700 font-medium text-base leading-[1.6] not-italic max-md:text-xs max-md:leading-[150%]">
-                졸업생의 경우, 졸업 후 0~2년 재직자에 한함
+                {recruitingTargetAudience.primaryNote}
               </p>
             </div>
             <p className="text-[#222227] font-bold text-xl leading-[160%] self-stretch max-md:text-sm max-md:leading-[160%] max-md:self-stretch">
-              최소 1년(2학기) 이상 활동할 수 있는 사람
+              {recruitingTargetAudience.durationRequirement}
             </p>
           </div>
         </div>
         <div className="flex items-start gap-[15.0625rem] self-stretch max-md:flex-col max-md:gap-4 max-md:self-stretch">
           <h4 className="text-[#222227] font-bold text-[2.5rem] leading-[140%] max-md:self-stretch max-md:text-xl max-md:leading-[160%]">
-            모집 분야 및<br className="hidden md:block" /> 우대 사항
+            {recruitingSectionTitles.fields.line1}
+            <br className="hidden md:block" /> {recruitingSectionTitles.fields.line2}
           </h4>
           <div className="flex flex-col items-start w-[52.9375rem] gap-5 max-md:gap-3 max-md:self-stretch max-md:w-full">
             <RecruitmentField />
@@ -49,121 +132,15 @@ export function Section04() {
         </div>
         <div className="flex items-start gap-[17.8125rem] max-md:flex-col max-md:gap-4 max-md:self-stretch">
           <h4 className="text-[#222227] whitespace-nowrap font-bold text-[2.5rem] leading-[140%] max-md:self-stretch max-md:text-xl max-md:leading-[160%]">
-            모집 일정
+            {recruitingSectionTitles.schedule}
           </h4>
           <div className="flex flex-col items-start gap-10 max-md:items-start max-md:gap-5 max-md:self-stretch">
-            <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
-              <h5 className="text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]">
-                1차 서류 모집
-              </h5>
-              <div className="flex items-start gap-3 pt-0.5 max-md:gap-2">
-                <div className="flex items-center gap-3 max-md:gap-2">
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                    11월 24일(월)
-                  </p>
-                  <div className="w-10 h-0.5 bg-[#222227] max-md:h-px" />
-                </div>
-                <div className="flex flex-col items-start gap-0.5 max-md:w-[7.2rem]">
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] self-stretch max-md:text-sm max-2xl:text-base">
-                    11월 30일(일)
-                  </p>
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] self-stretch max-md:text-sm max-2xl:text-base">
-                    오후 11시 59분 까지
-                  </p>
-                </div>
-              </div>
-            </div>
-            <svg className="w-full h-px self-stretch" preserveAspectRatio="none">
-              <rect width="100%" height="1" fill="rgba(70, 134, 255, 0.20)" />
-            </svg>
-            <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
-              <h5 className="text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]">
-                1차 결과 발표
-              </h5>
-              <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                12월 2일(화)
-              </p>
-            </div>
-
-            <svg className="w-full h-px self-stretch" preserveAspectRatio="none">
-              <rect width="100%" height="1" fill="rgba(70, 134, 255, 0.20)" />
-            </svg>
-            <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
-              <h5 className="text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]">
-                2차 대면 면접
-              </h5>
-              <div className="flex flex-col items-start pt-0.5 gap-4 max-md:gap-3">
-                <div className="flex items-center gap-3 self-stretch max-md:gap-2">
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                    12월 3일(수)
-                  </p>
-                  <div className="w-10 h-0.5 bg-[#222227] max-md:h-px" />
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                    12월 6일(토)
-                  </p>
-                </div>
-
-                <p
-                  className="text-[#80808B] text-base font-medium leading-[160%]
-                max-md:self-stretch max-md:text-xs max-md:leading-[150%] max-2xl:text-sm"
-                >
-                  *면접 일정 및 장소는 추후 안내
-                </p>
-              </div>
-            </div>
-            <svg className="w-full h-px self-stretch" preserveAspectRatio="none">
-              <rect width="100%" height="1" fill="rgba(70, 134, 255, 0.20)" />
-            </svg>
-            <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
-              <h5 className="text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]">
-                최종 결과 발표
-              </h5>
-              <div className="flex flex-col items-start w-[7.75rem] pt-0.5 gap-4 max-md:w-[4.6875rem] max-md:gap-3">
-                <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                  12월 7일(일)
-                </p>
-                <p className="text-[#80808B] text-base font-medium leading-[160%] max-md:text-xs max-md:leading-[150%] max-2xl:text-sm">
-                  *개별 안내 예정
-                </p>
-              </div>
-            </div>
-            <svg className="w-full h-px self-stretch" preserveAspectRatio="none">
-              <rect width="100%" height="1" fill="rgba(70, 134, 255, 0.20)" />
-            </svg>
-            <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
-              <h5 className="text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]">
-                합격자 온보딩
-              </h5>
-              <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                12월 28일(일)
-              </p>
-            </div>
-            <svg className="w-full h-px self-stretch" preserveAspectRatio="none">
-              <rect width="100%" height="1" fill="rgba(70, 134, 255, 0.20)" />
-            </svg>
-            <div className="flex h-[5.125rem] items-start gap-[5.875rem] max-md:flex-col max-md:gap-4">
-              <h5 className="text-[#222227] text-[1.75rem] font-bold leading-[150%] w-[14.4375rem] max-md:text-lg  max-md:leading-[160%]">
-                합격자 워크샵
-              </h5>
-              <div className="flex flex-col items-start pt-0.5 gap-4 max-md:gap-3">
-                <div className="flex items-center gap-3 self-stretch max-md:gap-2">
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                    1월 3일(토)
-                  </p>
-                  <div className="w-10 h-0.5 bg-[#222227] max-md:h-px" />
-                  <p className="text-[#222227] text-xl font-medium leading-[160%] max-md:self-stretch max-md:text-sm max-2xl:text-base">
-                    1월 4일(일)
-                  </p>
-                </div>
-
-                <p
-                  className="text-[#80808B] text-base font-medium leading-[160%] max-md:self-stretch
-                max-md:text-xs max-md:leading-[150%] max-2xl:text-sm"
-                >
-                  *1박 2일 참여 필수
-                </p>
-              </div>
-            </div>
+            {recruitingSchedule.map((entry, index) => (
+              <Fragment key={`${entry.kind}-${entry.title}`}>
+                <ScheduleRow entry={entry} />
+                {index < recruitingSchedule.length - 1 ? <ScheduleDivider /> : null}
+              </Fragment>
+            ))}
           </div>
         </div>
       </div>

--- a/apps/teampage/src/page/Recruiting-page/section/Section04.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section04.tsx
@@ -82,7 +82,7 @@ function ScheduleRow({ entry }: { entry: RecruitingScheduleEntry }) {
 export function Section04() {
   return (
     <div
-      className="flex flex-col items-start self-stretch gap-40 bg-[linear-gradient(180deg,rgba(255,255,255,0.07)_0%,rgba(70,134,255,0.07)_80%,rgba(255,255,255,0.07)_100%)] px-80 pt-20 pb-[200px]
+      className="flex flex-col items-start self-stretch gap-40 bg-[linear-gradient(180deg,rgba(255,255,255,0.07)_0%,rgba(70,134,255,0.07)_80%,rgba(255,255,255,0.07)_100%)] px-44 pt-20 pb-[200px]
     max-lg:gap-[3.75rem] max-lg:w-full max-lg:pt-7 max-lg:px-4 max-lg:pb-[4.5rem]"
     >
       <h3
@@ -121,7 +121,7 @@ export function Section04() {
             </p>
           </div>
         </div>
-        <div className="flex items-start gap-[15.0625rem] self-stretch max-md:flex-col max-md:gap-4 max-md:self-stretch">
+        <div className="flex items-start justify-between self-stretch max-md:flex-col max-md:gap-1 max-md:self-stretch">
           <h4 className="text-[#222227] font-bold text-[2.5rem] leading-[140%] max-md:self-stretch max-md:text-xl max-md:leading-[160%]">
             {recruitingSectionTitles.fields.line1}
             <br className="hidden md:block" /> {recruitingSectionTitles.fields.line2}
@@ -130,11 +130,11 @@ export function Section04() {
             <RecruitmentField />
           </div>
         </div>
-        <div className="flex items-start gap-[17.8125rem] max-md:flex-col max-md:gap-4 max-md:self-stretch">
+        <div className="flex items-start w-full justify-between max-md:flex-col max-md:self-stretch">
           <h4 className="text-[#222227] whitespace-nowrap font-bold text-[2.5rem] leading-[140%] max-md:self-stretch max-md:text-xl max-md:leading-[160%]">
             {recruitingSectionTitles.schedule}
           </h4>
-          <div className="flex flex-col items-start gap-10 max-md:items-start max-md:gap-5 max-md:self-stretch">
+          <div className="flex flex-col items-start w-[73%] gap-10 max-md:items-start max-md:gap-5 max-md:self-stretch">
             {recruitingSchedule.map((entry, index) => (
               <Fragment key={`${entry.kind}-${entry.title}`}>
                 <ScheduleRow entry={entry} />

--- a/apps/teampage/src/page/Recruiting-page/section/Section05.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section05.tsx
@@ -1,59 +1,18 @@
 'use client';
 import { useState } from 'react';
+
+import { recruitingFaqItems, recruitingFaqSectionTitle } from '@/page/Recruiting-page/config';
+
 import { FAQbutton } from './FAQbutton';
 
-const Section5text: Array<{
-  question: string;
-  answer: string[];
-}> = [
-  {
-    question: 'Q. 시대생 앱은 어떻게 생겨 났나요?',
-    answer: [
-      '2020년 5월, 코로나19로 인한 서울시립대학교의 동문 단절로 인한 문제를 해결하고자 학부생 4명이 모여 시작했습니다.',
-      '비대면 수업 지원, 코로나 학번의 소통 단절, 동문 연결의 부재 등 서울시립대 내의 연결이 필요한 모든 영역을 IT 기술을 통해 해결하고 혁신하고자 했고, 그 결과 서울시립대의 대표 IT 프로덕트 시대생과 UOSLIFE 동아리가 탄생했습니다.',
-      'UOSLIFE는 IT 업계를 희망하는 재학생부터, 현직 주니어로 있는 졸업생들까지 서로의 고민을 공유하고 도우며 이제는 교내를 넘어 국내 IT 업계 최고의 엘리트 공동체로 성장하고자 하는 비전을 갖고 있습니다.',
-    ],
-  },
-  {
-    question: 'Q. 정기 모임은 언제, 어디서 하나요?',
-    answer: [
-      'UOSLIFE는 격주 목요일 저녁 7시 30분에 정기 팀 회의를 진행하고 있습니다. 팀 회의는 각 TF의 활동 공유&친목 도모를 위해 진행되며 가벼운 뒤풀이가 있을 수 있습니다.',
-      '매 방학 시즌에는 신규 기능 개발 프로젝트를 진행하며, 이 경우 격주 토요일에 전일(10AM.-10PM.)으로 모여 코어 타임을 갖고 있습니다. 이번 겨울 프로젝트는 1/3(토)를 기점으로 진행될 예정입니다.',
-      '*모든 모임은 오프라인 대면으로 진행되고 있으며 프로젝트 상황에 따라 달라질 수 있습니다.',
-    ],
-  },
-  {
-    question: 'Q. 졸업생도 지원이 가능한가요?',
-    answer: [
-      '1년간 꾸준히 활동할 수 있고 배우고자 하는 열의가 충분하다면, 누구든 지원이 가능합니다. 현재도 재학생, 휴학생, 졸업생 중 활발히 활동하시는 분들이 계십니다.',
-      '하지만, 매월 둘째 주, 넷째 주에 진행하는 정기 회의 (목요일 7시 30분)와 방학 기간 동안의 *프로젝트 코어 타임은 반드시 참여해야 한다는 점은 꼭 숙지해 주세요!',
-      '*프로젝트 코어 타임: 1월 3일부터 격주 토요일 전일',
-    ],
-  },
-  {
-    question: 'Q. 실력이 뛰어난 사람만 지원할 수 있나요?',
-    answer: [
-      'UOSLIFE에서는 1년간 꾸준히 활동할 수 있는지, 그리고 성장하고자 하는 의지가 충분한지를 가장 중요하게 생각합니다.',
-      '그러나 교육보다는 프로젝트 진행 중심이기에 내부 현직 특강, 기초 교육 외에는 별도의 체계적인 교육 커리큘럼을 진행하고 있지 않습니다. 따라서, 동아리 활동 외에도 개인적인 노력이 함께 되어야 함을 알아주시길 바랍니다.',
-    ],
-  },
-  {
-    question: 'Q. UOSLIFE Alummi (졸업생 및 동문)도 함께 활동하나요?',
-    answer: [
-      '네, 함께 활동합니다. 학기에 따라 다르지만 UOSLIFE 동아리를 졸업한 Alumni들도 지속적으로 활동하고 있습니다.',
-      '방학 프로젝트 및 현직자 특강 등을 통해 재학생들의 성장을 지원하고, 내부 네트워킹 및 현직자 모임을 통해 지속적으로 교류하고 있습니다.',
-    ],
-  },
-];
-
-const QandAchild = ({ item, index }) => {
+function QandAchild({ item, index }: { item: (typeof recruitingFaqItems)[number]; index: number }) {
   const initS = index === 0 ? true : false;
   const [open, setOpen] = useState(initS);
   return (
     <div key={index} className="flex flex-col items-start gap-5 self-stretch max-md:gap-4 ">
       <FAQbutton question={item.question} open={open} setOpen={setOpen} />
       {open && (
-        <div className="flex flex-col items-start w-[1063px]  gap-5 items-start max-md:gap-2 max-md:self-stretch max-2xl:w-[100%]">
+        <div className="flex flex-col w-[1063px]  gap-5 items-start max-md:gap-2 max-md:self-stretch max-2xl:w-[100%]">
           {item.answer.map((answeritem, answerIndex) => (
             <p
               key={answerIndex}
@@ -65,19 +24,19 @@ const QandAchild = ({ item, index }) => {
           ))}
         </div>
       )}
-      {index !== Section5text.length - 1 && (
+      {index !== recruitingFaqItems.length - 1 && (
         <svg className="w-full h-[1px]" preserveAspectRatio="none">
           <line x1="0" y1="0" x2="100%" y2="0" stroke="#E1E1E7" strokeWidth="1" />
         </svg>
       )}
     </div>
   );
-};
+}
 
 const QandA = () => {
   return (
     <>
-      {Section5text.map((item, index) => {
+      {recruitingFaqItems.map((item, index) => {
         return <QandAchild key={index} item={item} index={index} />;
       })}
     </>
@@ -88,7 +47,7 @@ export function Section05() {
   return (
     <div className="flex flex-col items-start w-full gap-20 w-full max-md:gap-7 px-[16.66667%] pb-[120px] max-md:pb-[60px] max-md:px-4">
       <h3 className="text-[#222227] font-bold text-[72px] leading-[120%] self-stretch max-md:text-[32px] max-md:leading-[140%]">
-        자주 묻는 질문
+        {recruitingFaqSectionTitle}
       </h3>
       <div
         className="flex flex-col items-start gap-7 self-stretch

--- a/apps/teampage/src/page/Recruiting-page/section/Section06.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section06.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { forwardRef } from 'react';
+
+import { recruitingSection06 } from '@/page/Recruiting-page/config';
+
 import { Recruitbutton } from './Recruitbutton';
 
 export const Section06 = forwardRef<HTMLDivElement, any>((_, ref) => {
@@ -12,11 +15,11 @@ export const Section06 = forwardRef<HTMLDivElement, any>((_, ref) => {
       <div className="flex flex-col items-center gap-12 max-md:gap-7">
         <div className="flex flex-col items-center gap-3 max-md:gap-3">
           <h3 className="text-center font-bold text-[4.5rem] leading-[120%] bg-gradient-to-r from-black via-blue-600 to-blue-200 bg-clip-text text-transparent max-md:text-[2rem] max-md:leading-[140%]">
-            모집 기간이 <br />
-            종료되었어요
+            {recruitingSection06.headlineLine1} <br />
+            {recruitingSection06.headlineLine2}
           </h3>
           <p className="text-center text-[#54545C] text-[1.125rem] font-medium leading-[160%] max-md:text-sm w-[100%] max-md:w-[80%]">
-            다음 모집 알림을 받으면 빠르게 지원할 수 있어요!
+            {recruitingSection06.description}
           </p>
         </div>
         <Recruitbutton />

--- a/apps/teampage/src/page/Recruiting-page/section/Section07.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section07.tsx
@@ -1,20 +1,22 @@
-import Link from 'next/link';
 import Image from 'next/image';
+import Link from 'next/link';
+
+import { recruitingAssets, recruitingSection07 } from '@/page/Recruiting-page/config';
 
 export function Section07() {
+  const c = recruitingSection07;
   return (
     <>
       <div className="flex flex-col items-start gap-20 self-stretch py-60 px-20 max-md:px-4 max-md:py-[84px] max-md:gap-7 max-xl:px-[10%] ">
         <h2 className="text-[#222227] font-pretendard text-[72px] leading-[120%] self-stretch max-md:text-[32px] font-bold max-md:leading-[140%]">
-          더 궁금한 게 있다면
+          {c.headlineLine1}
           <br />
-          아래를 통해 문의해 주세요
+          {c.headlineLine2}
         </h2>
 
         <div className="flex items-center gap-10 self-stretch max-md:gap-2">
-          {/* 카드 1 */}
           <Link
-            href="https://pf.kakao.com/_gMEHK"
+            href={c.kakaoHref}
             target="_blank"
             className="flex h-[400px] p-12 flex-col justify-between items-start flex-1 rounded-[20px] bg-white/80 shadow-[0_0_16px_0_rgba(70,134,255,0.12)] max-md:h-60 max-md:p-4 max-md:rounded-lg"
           >
@@ -22,7 +24,8 @@ export function Section07() {
               className="self-stretch opacity-95 text-[#222227] font-['Pretendard'] text-[40px] font-bold leading-[140%] max-md:text-xl max-md:leading-[160%]
             "
             >
-              <span className="text-[#4686FF]">UOSLIFE</span>에 궁금한 점이나 의견이 있다면?
+              <span className="text-[#4686FF]">{c.brandAccentName}</span>
+              {c.kakaoCardTitleSuffix}
             </p>
 
             <div className="flex items-center gap-2 max-md:gap-1 max-md:self-stretch">
@@ -31,36 +34,36 @@ export function Section07() {
               max-md:flex-1 max-md:text-sm 
               "
               >
-                시대생 카카오톡 채널 바로가기
+                {c.kakaoCardLinkLabel}
               </p>
               <div className="flex w-6 h-6 justify-center items-center gap-2.5 max-md:w-4 max-md:h-4 max-md:gap-[6.667px]">
-                <Image src="/img/recruit/anglebracket.svg" alt="bracket" width={8} height={8} />
+                <Image src={recruitingAssets.angleBracket} alt="bracket" width={8} height={8} />
               </div>
             </div>
           </Link>
 
-          {/* 카드 2 */}
           <Link
-            href="https://www.instagram.com/uoslife_official/"
+            href={c.instagramHref}
             target="_blank"
             className="flex h-[400px] p-12 flex-col justify-between items-start flex-1 rounded-[20px] bg-white/80 shadow-[0_0_16px_0_rgba(70,134,255,0.12)] max-md:h-60 max-md:p-4 max-md:rounded-lg"
           >
             <p className="self-stretch opacity-95 text-[#222227] font-['Pretendard'] text-[40px] font-bold leading-[140%] max-md:text-xl max-md:leading-[160%]">
-              <span className="text-[#4686FF]">UOSLIFE</span>의 실시간 소식을 알고 싶다면?
+              <span className="text-[#4686FF]">{c.brandAccentName}</span>
+              {c.instagramCardTitleSuffix}
             </p>
             <div
               className="flex items-center gap-2
             max-md:gap-1 max-md:self-stretch"
             >
               <p className="text-[#54545C] font-['Pretendard'] text-xl font-bold leading-[160%] max-md:flex-1 max-md:text-sm ">
-                시대생 인스타그램 바로가기
+                {c.instagramCardLinkLabel}
               </p>
               <div
                 className="flex w-6 h-6 justify-center items-center gap-2.5
               max-md:w-4 max-md:h-4 max-md:gap-[6.667px]
               "
               >
-                <Image src="/img/recruit/anglebracket.svg" alt="bracket" width={8} height={8} />
+                <Image src={recruitingAssets.angleBracket} alt="bracket" width={8} height={8} />
               </div>
             </div>
           </Link>

--- a/apps/teampage/src/page/Recruiting-page/section/Section07.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section07.tsx
@@ -4,8 +4,8 @@ import Image from 'next/image';
 export function Section07() {
   return (
     <>
-      <div className="flex flex-col items-start gap-20 self-stretch py-60 px-80 max-md:px-4 max-md:py-[84px] max-md:gap-7 max-xl:px-[10%] ">
-        <h2 className="text-[#222227] font-pretendard text-[72px] font-bold leading-[120%] self-stretch max-md:text-[32px] font-bold max-md:leading-[140%]">
+      <div className="flex flex-col items-start gap-20 self-stretch py-60 px-20 max-md:px-4 max-md:py-[84px] max-md:gap-7 max-xl:px-[10%] ">
+        <h2 className="text-[#222227] font-pretendard text-[72px] leading-[120%] self-stretch max-md:text-[32px] font-bold max-md:leading-[140%]">
           더 궁금한 게 있다면
           <br />
           아래를 통해 문의해 주세요
@@ -22,9 +22,7 @@ export function Section07() {
               className="self-stretch opacity-95 text-[#222227] font-['Pretendard'] text-[40px] font-bold leading-[140%] max-md:text-xl max-md:leading-[160%]
             "
             >
-              <span className="text-[#4686FF]">UOSLIFE</span>에 궁금한 점이나
-              <br />
-              의견이 있다면?
+              <span className="text-[#4686FF]">UOSLIFE</span>에 궁금한 점이나 의견이 있다면?
             </p>
 
             <div className="flex items-center gap-2 max-md:gap-1 max-md:self-stretch">
@@ -48,9 +46,7 @@ export function Section07() {
             className="flex h-[400px] p-12 flex-col justify-between items-start flex-1 rounded-[20px] bg-white/80 shadow-[0_0_16px_0_rgba(70,134,255,0.12)] max-md:h-60 max-md:p-4 max-md:rounded-lg"
           >
             <p className="self-stretch opacity-95 text-[#222227] font-['Pretendard'] text-[40px] font-bold leading-[140%] max-md:text-xl max-md:leading-[160%]">
-              <span className="text-[#4686FF]">UOSLIFE</span>의 실시간 소식을
-              <br />
-              알고 싶다면?
+              <span className="text-[#4686FF]">UOSLIFE</span>의 실시간 소식을 알고 싶다면?
             </p>
             <div
               className="flex items-center gap-2

--- a/apps/teampage/src/shared/component/TabButton.tsx
+++ b/apps/teampage/src/shared/component/TabButton.tsx
@@ -14,9 +14,9 @@ export function TabButton({ children, color = 'light', clicked, className, ...pr
       textColor: clicked ? 'black' : 'grey-600',
     },
     dark: {
-      default: 'bg-[#8E8E93] hover:bg-[#E1E1E7] hover:text-[#54545C]',
-      clicked: 'text-black',
-      textColor: clicked ? 'black' : 'grey-600',
+      default: 'px-4 rounded-[22px] bg-grey-800 hover:bg-grey-200 hover:text-grey-700',
+      clicked: 'px-4 rounded-[22px] grey-900 bg-grey-50',
+      textColor: clicked ? 'grey-900' : 'grey-600',
     },
   };
 

--- a/apps/teampage/src/widgets/header/Header.tsx
+++ b/apps/teampage/src/widgets/header/Header.tsx
@@ -2,7 +2,7 @@
 import { useAuth } from '@entities/auth/useAuth';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { Text } from '@/shared/component/Text';
 import { usePathname } from 'next/navigation';
@@ -44,6 +44,11 @@ export default function Header() {
   const pathname = usePathname();
   const { isMobile } = useDevice();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [ourStoryMenuOpen, setOurStoryMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setOurStoryMenuOpen(false);
+  }, [pathname]);
 
   const handleCloseMenu = useCallback(() => {
     if (!isMobile) return;
@@ -52,11 +57,49 @@ export default function Header() {
 
   const renderLink = useCallback(
     (route: { path: string; name: string }) => {
-      const isShowOurStoryMenu = route.path === ROUTE.OUR_STORY.path;
-      const isActive = pathname === route.path;
+      const isOurStory = route.name === 'Our Story';
+      const isActive = isOurStory ? pathname === '/career' || pathname === '/moments' : pathname === route.path;
+
+      if (isOurStory) {
+        return (
+          <div className="relative group" key={route.path}>
+            <button
+              type="button"
+              className="w-full"
+              aria-expanded={ourStoryMenuOpen}
+              aria-haspopup="true"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOurStoryMenuOpen((open) => !open);
+              }}
+            >
+              <div
+                className="content-stretch flex items-center justify-center px-[10px] py-[12px]"
+                data-name={`GNB_Tap_${route.name}`}
+              >
+                <p
+                  className={twMerge(
+                    'text-body-18-b whitespace-pre cursor-pointer transition-colors text-left',
+                    isActive ? 'text-primary-ui' : 'hover:text-primary-ui text-gray-800',
+                  )}
+                >
+                  {route.name}
+                </p>
+              </div>
+            </button>
+            <OurStoryMenu
+              forceOpen={ourStoryMenuOpen}
+              onItemNavigate={() => {
+                setOurStoryMenuOpen(false);
+                handleCloseMenu();
+              }}
+            />
+          </div>
+        );
+      }
 
       return (
-        <div className={`relative ${isShowOurStoryMenu ? 'group' : ''} `} key={route.path}>
+        <div className="relative" key={route.path}>
           <Link href={route.path} className="w-full group" onClick={handleCloseMenu}>
             <div
               className="content-stretch flex items-center justify-center px-[10px] py-[12px]"
@@ -72,11 +115,10 @@ export default function Header() {
               </p>
             </div>
           </Link>
-          <OurStoryMenu />
         </div>
       );
     },
-    [pathname, ROUTE.OUR_STORY.path, handleCloseMenu],
+    [pathname, handleCloseMenu, ourStoryMenuOpen],
   );
 
   return (
@@ -270,17 +312,22 @@ export default function Header() {
   );
 }
 
-function OurStoryMenu() {
+function OurStoryMenu({ forceOpen, onItemNavigate }: { forceOpen: boolean; onItemNavigate?: () => void }) {
   return (
-    <div className="hidden group-hover:block top-full w-40 bg-white box-border flex-col gap-2 items-start justify-start p-[12px] rounded-2xl shadow-[0px_0px_12px_0px_rgba(18,18,18,0.1)] absolute transform translate-x-[-22%]">
-      <Link href="/career" className="w-full group/career">
+    <div
+      className={twMerge(
+        'absolute top-full left-0 w-40 gap-2 items-start justify-start bg-white box-border p-[12px] rounded-2xl shadow-[0px_0px_12px_0px_rgba(18,18,18,0.1)] z-[60]',
+        forceOpen ? 'flex flex-col' : 'hidden group-hover:flex flex-col',
+      )}
+    >
+      <Link href="/career" className="w-full group/career" onClick={() => onItemNavigate?.()}>
         <div className="box-border content-stretch flex flex-row gap-2.5 h-11 items-center justify-center px-4 py-1.5 relative rounded-[40px] w-full hover:bg-gray-100">
           <Text variant="body-18-m" className="group-hover/career:text-primary-ui">
             Career
           </Text>
         </div>
       </Link>
-      <Link href="/moments" className="w-full group/moments">
+      <Link href="/moments" className="w-full group/moments" onClick={() => onItemNavigate?.()}>
         <div className="box-border content-stretch flex flex-row gap-2.5 h-11 items-center justify-center px-4 py-1.5 relative rounded-[40px] w-full hover:bg-gray-100">
           <Text variant="body-18-m" className="group-hover/moments:text-primary-ui">
             Moments


### PR DESCRIPTION
# 리크루팅 페이지 설정

리크루팅 관련 정적 값은 **`config.ts`** 에서만 수정하면 됩니다.

---

## Section별 대응 변수

### 공통 · 플로팅 버튼 등

- `recruitingAssets`
- `recruitingBrand`
- `recruitingDates`
- `recruitingApplicationSeasonYear`
- `recruitingCallToAction`
- `recruitingApplyButtonLabel()`
- `isRecruitingApplicationActive()`

### Section01

- `recruitingAssets.heroLogoBackground`
- `recruitingBrand`
- `recruitingPeriod` (`recruitingDates.documentSubmission` 기준으로 생성됨)

### Section02

- `recruitingSection02`
- `recruitingMentorSectionHeading()`
- `recruitingAssets.angleBracket`

### Section03

- `recruitingSection03`

### Section04

- `recruitingHeadline`
- `recruitingTargetAudience`
- `recruitingSectionTitles`
- `recruitingSchedule` (일정 문자열은 `recruitingDates` 참조)
- `recruitingFieldDetailLabels`
- `recruitingRoles`

### Section05

- `recruitingFaqSectionTitle`
- `recruitingFaqItems`

### Section06

- `recruitingSection06`

### Section07

- `recruitingSection07`
- `recruitingAssets.angleBracket`
