### PR TITLE
chore: 리쿠르팅 탭 세부 내용 수정 사항 반영

### DIFF
--- a/apps/teampage/src/page/Recruiting-page/config.ts
+++ b/apps/teampage/src/page/Recruiting-page/config.ts
@@ -95,6 +95,35 @@ export function recruitingDateWithoutWeekday(dayLabel: string): string {
   return dayLabel.replace(/\s*\([^)]*\)\s*$/, '').trim();
 }
 
+/** `7월 11일(토)` → `7/11` — FAQ 등 짧은 표기 */
+export function recruitingMonthDaySlashFromLabel(dayLabel: string): string {
+  const plain = recruitingDateWithoutWeekday(dayLabel);
+  const { month, day } = parseMonthDayFromRecruitingLabel(plain);
+  return `${month}/${day}`;
+}
+
+/** KST 기준 월로 방학 프로젝트 안내를 여름/겨울 중 하나로 (`recruitingDates.workshop` 월로 보조 판별) */
+export function recruitingVacationProjectSeasonWord(now: Date = new Date()): '여름' | '겨울' {
+  const month = Number(new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul', month: 'numeric' }).format(now));
+  if (month >= 7 && month <= 8) return '여름';
+  if (month === 12 || month <= 2) return '겨울';
+  const { month: wsMonth } = parseMonthDayFromRecruitingLabel(
+    recruitingDateWithoutWeekday(recruitingDates.workshop.start),
+  );
+  if (wsMonth >= 6 && wsMonth <= 9) return '여름';
+  return '겨울';
+}
+
+/** `5월 10일(일)` → `5/10(일)` — 모집 마감 안내 등 */
+export function recruitingDocumentDueSlashWithWeekday(): string {
+  const due = recruitingDates.documentSubmission.due;
+  const weekMatch = due.match(/\(([^)]+)\)\s*$/);
+  const weekday = weekMatch ? weekMatch[1] : '';
+  const plain = recruitingDateWithoutWeekday(due);
+  const { month, day } = parseMonthDayFromRecruitingLabel(plain);
+  return `${month}/${day}(${weekday})`;
+}
+
 /** 히어로(Section01) — 서류 접수 일정과 동일 소스 */
 export const recruitingPeriod = {
   rangeStartLabel: `${recruitingDateWithoutWeekday(recruitingDates.documentSubmission.open)}부터`,
@@ -153,8 +182,7 @@ export const recruitingSection03 = {
   title: 'Alumni Network',
   description:
     '네이버, 카카오페이, 라인, 리멤버 등 국내 최고의 IT 회사부터 SKT, 현대자동차, NH투자증권, 한국은행 등 유수의 대기업/금융권까지',
-  descriptionContinued:
-    '다양한 업계의 구성원이 지속적인 시너지를 주고 받을 수 있는 관계를 만들어갑니다.',
+  descriptionContinued: '다양한 업계의 구성원이 지속적인 시너지를 주고 받을 수 있는 관계를 만들어갑니다.',
   logoSvgCount: 11,
   carousel: {
     desktop: { tilePx: 200, gapPx: 20, loopTiles: 9, durationSec: 20 },
@@ -276,53 +304,94 @@ export function recruitingMentorSectionHeading(): string {
 /** Section05 FAQ */
 export const recruitingFaqSectionTitle = '자주 묻는 질문';
 
-export const recruitingFaqItems: ReadonlyArray<{ question: string; answer: readonly string[] }> = [
-  {
-    question: 'Q. 시대생 앱은 어떻게 생겨 났나요?',
-    answer: [
-      '2020년 5월, 코로나19로 인한 서울시립대학교의 동문 단절로 인한 문제를 해결하고자 학부생 4명이 모여 시작했습니다.',
-      '비대면 수업 지원, 코로나 학번의 소통 단절, 동문 연결의 부재 등 서울시립대 내의 연결이 필요한 모든 영역을 IT 기술을 통해 해결하고 혁신하고자 했고, 그 결과 서울시립대의 대표 IT 프로덕트 시대생과 UOSLIFE 동아리가 탄생했습니다.',
-      'UOSLIFE는 IT 업계를 희망하는 재학생부터, 현직 주니어로 있는 졸업생들까지 서로의 고민을 공유하고 도우며 이제는 교내를 넘어 국내 IT 업계 최고의 엘리트 공동체로 성장하고자 하는 비전을 갖고 있습니다.',
-    ],
-  },
-  {
-    question: 'Q. 정기 모임은 언제, 어디서 하나요?',
-    answer: [
-      'UOSLIFE는 격주 목요일 저녁 7시 30분에 정기 팀 회의를 진행하고 있습니다. 팀 회의는 각 TF의 활동 공유&친목 도모를 위해 진행되며 가벼운 뒤풀이가 있을 수 있습니다.',
-      '매 방학 시즌에는 신규 기능 개발 프로젝트를 진행하며, 이 경우 격주 토요일에 전일(10AM.-10PM.)으로 모여 코어 타임을 갖고 있습니다. 이번 겨울 프로젝트는 1/3(토)를 기점으로 진행될 예정입니다.',
-      '*모든 모임은 오프라인 대면으로 진행되고 있으며 프로젝트 상황에 따라 달라질 수 있습니다.',
-    ],
-  },
-  {
-    question: 'Q. 졸업생도 지원이 가능한가요?',
-    answer: [
-      '1년간 꾸준히 활동할 수 있고 배우고자 하는 열의가 충분하다면, 누구든 지원이 가능합니다. 현재도 재학생, 휴학생, 졸업생 중 활발히 활동하시는 분들이 계십니다.',
-      '하지만, 매월 둘째 주, 넷째 주에 진행하는 정기 회의 (목요일 7시 30분)와 방학 기간 동안의 *프로젝트 코어 타임은 반드시 참여해야 한다는 점은 꼭 숙지해 주세요!',
-      '*프로젝트 코어 타임: 1월 3일부터 격주 토요일 전일',
-    ],
-  },
-  {
-    question: 'Q. 실력이 뛰어난 사람만 지원할 수 있나요?',
-    answer: [
-      'UOSLIFE에서는 1년간 꾸준히 활동할 수 있는지, 그리고 성장하고자 하는 의지가 충분한지를 가장 중요하게 생각합니다.',
-      '그러나 교육보다는 프로젝트 진행 중심이기에 내부 현직 특강, 기초 교육 외에는 별도의 체계적인 교육 커리큘럼을 진행하고 있지 않습니다. 따라서, 동아리 활동 외에도 개인적인 노력이 함께 되어야 함을 알아주시길 바랍니다.',
-    ],
-  },
-  {
-    question: 'Q. UOSLIFE Alummi (졸업생 및 동문)도 함께 활동하나요?',
-    answer: [
-      '네, 함께 활동합니다. 학기에 따라 다르지만 UOSLIFE 동아리를 졸업한 Alumni들도 지속적으로 활동하고 있습니다.',
-      '방학 프로젝트 및 현직자 특강 등을 통해 재학생들의 성장을 지원하고, 내부 네트워킹 및 현직자 모임을 통해 지속적으로 교류하고 있습니다.',
-    ],
-  },
-];
+export type RecruitingFaqItem = { question: string; answer: readonly string[] };
 
-/** Section06 — 모집 종료 안내 */
-export const recruitingSection06 = {
+/** 표시 시점(KST 월·워크샵 일정) 기준으로 방학 프로젝트 문구 등 반영 */
+export function buildRecruitingFaqItems(now: Date = new Date()): ReadonlyArray<RecruitingFaqItem> {
+  const vacationSeason = recruitingVacationProjectSeasonWord(now);
+  const workshopStartSlash = recruitingMonthDaySlashFromLabel(recruitingDates.workshop.start);
+
+  return [
+    {
+      question: 'Q. 시대생 앱은 어떻게 생겨 났나요?',
+      answer: [
+        '2020년 5월, 코로나19로 인한 서울시립대학교의 동문 단절로 인한 문제를 해결하고자 학부생 4명이 모여 시작했습니다.',
+        '비대면 수업 지원, 코로나 학번의 소통 단절, 동문 연결의 부재 등 서울시립대 내의 연결이 필요한 모든 영역을 IT 기술을 통해 해결하고 혁신하고자 했고, 그 결과 서울시립대의 대표 IT 프로덕트 시대생과 UOSLIFE 동아리가 탄생했습니다.',
+        'UOSLIFE는 IT 업계를 희망하는 재학생부터, 현직 주니어로 있는 졸업생들까지 서로의 고민을 공유하고 도우며 이제는 교내를 넘어 국내 IT 업계 최고의 엘리트 공동체로 성장하고자 하는 비전을 갖고 있습니다.',
+      ],
+    },
+    {
+      question: 'Q. 정기 모임은 언제, 어디서 하나요?',
+      answer: [
+        'UOSLIFE는 격주 목요일 저녁 7시 30분에 정기 팀 회의를 진행하고 있습니다. 팀 회의는 각 TF의 활동 공유&친목 도모를 위해 진행되며 가벼운 뒤풀이가 있을 수 있습니다.',
+        `매 방학 시즌에는 신규 기능 개발 프로젝트를 진행하며, 이 경우 격주 토요일에 전일(10AM.-10PM.)으로 모여 코어 타임을 갖고 있습니다. 이번 ${vacationSeason}방학 프로젝트는 ${workshopStartSlash} 부터 진행될 예정입니다.`,
+        '*모든 모임은 오프라인 대면으로 진행되고 있으며 프로젝트 상황에 따라 달라질 수 있습니다.',
+      ],
+    },
+    {
+      question: 'Q. 졸업생도 지원이 가능한가요?',
+      answer: [
+        '1년간 꾸준히 활동할 수 있고 배우고자 하는 열의가 충분하다면, 누구든 지원이 가능합니다. 현재도 재학생, 휴학생, 졸업생 중 활발히 활동하시는 분들이 계십니다.',
+        '하지만, 매월 둘째 주, 넷째 주에 진행하는 정기 회의 (목요일 7시 30분)와 방학 기간 동안의 *프로젝트 코어 타임은 반드시 참여해야 한다는 점은 꼭 숙지해 주세요!',
+        '*프로젝트 코어 타임: 7월 11일부터 격주 토요일 전일',
+      ],
+    },
+    {
+      question: 'Q. 실력이 뛰어난 사람만 지원할 수 있나요?',
+      answer: [
+        'UOSLIFE에서는 1년간 꾸준히 활동할 수 있는지, 그리고 성장하고자 하는 의지가 충분한지를 가장 중요하게 생각합니다.',
+        '그러나 교육보다는 프로젝트 진행 중심이기에 내부 현직 특강, 기초 교육 외에는 별도의 체계적인 교육 커리큘럼을 진행하고 있지 않습니다. 따라서, 동아리 활동 외에도 개인적인 노력이 함께 되어야 함을 알아주시길 바랍니다.',
+      ],
+    },
+    {
+      question: 'Q. UOSLIFE Alummi (졸업생 및 동문)도 함께 활동하나요?',
+      answer: [
+        '네, 함께 활동합니다. 학기에 따라 다르지만 UOSLIFE 동아리를 졸업한 Alumni들도 지속적으로 활동하고 있습니다.',
+        '방학 프로젝트 및 현직자 특강 등을 통해 재학생들의 성장을 지원하고, 내부 네트워킹 및 현직자 모임을 통해 지속적으로 교류하고 있습니다.',
+      ],
+    },
+  ];
+}
+
+/** Section06 — 모집 종료 시 노출 문구 */
+export const recruitingSection06Inactive = {
   headlineLine1: '모집 기간이',
   headlineLine2: '종료되었어요',
-  description: '다음 모집 알림을 받으면 빠르게 지원할 수 있어요!',
+  detail: '다음 모집 알림을 받으면 빠르게 지원할 수 있어요!',
 } as const;
+
+/** Section06 — 모집 진행 중 타이틀(보조 문단은 마감 일정에서 생성) */
+export const recruitingSection06Active = {
+  headlineLine1: 'UOSLIFE에서',
+  headlineLine2: '여러분을 기다립니다',
+} as const;
+
+/** 모집 중 Section06 보조 문단 — `documentSubmission.due` · `dueTimeNote` 단일 소스 */
+export function buildRecruitingSection06DeadlineDetail(): string {
+  const md = recruitingDocumentDueSlashWithWeekday();
+  const timeCore = recruitingDates.documentSubmission.dueTimeNote.replace(/\s*까지\s*$/, '').trim();
+  return `${md} ${timeCore}까지 하단의 링크를 통해 지원서를 제출해 주세요.`;
+}
+
+/** 모집 진행 여부에 따라 Section06 타이틀·보조 문단 결정 */
+export function resolveRecruitingSection06Texts(now?: Date): {
+  headlineLine1: string;
+  headlineLine2: string;
+  detail: string;
+} {
+  if (isRecruitingApplicationActive(now)) {
+    return {
+      headlineLine1: recruitingSection06Active.headlineLine1,
+      headlineLine2: recruitingSection06Active.headlineLine2,
+      detail: buildRecruitingSection06DeadlineDetail(),
+    };
+  }
+  return {
+    headlineLine1: recruitingSection06Inactive.headlineLine1,
+    headlineLine2: recruitingSection06Inactive.headlineLine2,
+    detail: recruitingSection06Inactive.detail,
+  };
+}
 
 /** Section07 — 문의 카드 */
 export const recruitingSection07 = {

--- a/apps/teampage/src/page/Recruiting-page/section/Section05.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section05.tsx
@@ -1,11 +1,15 @@
 'use client';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
-import { recruitingFaqItems, recruitingFaqSectionTitle } from '@/page/Recruiting-page/config';
+import {
+  buildRecruitingFaqItems,
+  recruitingFaqSectionTitle,
+  type RecruitingFaqItem,
+} from '@/page/Recruiting-page/config';
 
 import { FAQbutton } from './FAQbutton';
 
-function QandAchild({ item, index }: { item: (typeof recruitingFaqItems)[number]; index: number }) {
+function QandAchild({ item, index, total }: { item: RecruitingFaqItem; index: number; total: number }) {
   const initS = index === 0 ? true : false;
   const [open, setOpen] = useState(initS);
   return (
@@ -24,7 +28,7 @@ function QandAchild({ item, index }: { item: (typeof recruitingFaqItems)[number]
           ))}
         </div>
       )}
-      {index !== recruitingFaqItems.length - 1 && (
+      {index !== total - 1 && (
         <svg className="w-full h-[1px]" preserveAspectRatio="none">
           <line x1="0" y1="0" x2="100%" y2="0" stroke="#E1E1E7" strokeWidth="1" />
         </svg>
@@ -33,17 +37,19 @@ function QandAchild({ item, index }: { item: (typeof recruitingFaqItems)[number]
   );
 }
 
-const QandA = () => {
+function QandA({ items }: { items: ReadonlyArray<RecruitingFaqItem> }) {
   return (
     <>
-      {recruitingFaqItems.map((item, index) => {
-        return <QandAchild key={index} item={item} index={index} />;
+      {items.map((item, index) => {
+        return <QandAchild key={index} item={item} index={index} total={items.length} />;
       })}
     </>
   );
-};
+}
 
 export function Section05() {
+  const faqItems = useMemo(() => buildRecruitingFaqItems(), []);
+
   return (
     <div className="flex flex-col items-start w-full gap-20 w-full max-md:gap-7 px-[16.66667%] pb-[120px] max-md:pb-[60px] max-md:px-4">
       <h3 className="text-[#222227] font-bold text-[72px] leading-[120%] self-stretch max-md:text-[32px] max-md:leading-[140%]">
@@ -53,7 +59,7 @@ export function Section05() {
         className="flex flex-col items-start gap-7 self-stretch
       max-md:gap-4"
       >
-        <QandA />
+        <QandA items={faqItems} />
       </div>
     </div>
   );

--- a/apps/teampage/src/page/Recruiting-page/section/Section06.tsx
+++ b/apps/teampage/src/page/Recruiting-page/section/Section06.tsx
@@ -2,11 +2,13 @@
 
 import { forwardRef } from 'react';
 
-import { recruitingSection06 } from '@/page/Recruiting-page/config';
+import { resolveRecruitingSection06Texts } from '@/page/Recruiting-page/config';
 
 import { Recruitbutton } from './Recruitbutton';
 
 export const Section06 = forwardRef<HTMLDivElement, any>((_, ref) => {
+  const section06Texts = resolveRecruitingSection06Texts();
+
   return (
     <div
       ref={ref}
@@ -15,11 +17,11 @@ export const Section06 = forwardRef<HTMLDivElement, any>((_, ref) => {
       <div className="flex flex-col items-center gap-12 max-md:gap-7">
         <div className="flex flex-col items-center gap-3 max-md:gap-3">
           <h3 className="text-center font-bold text-[4.5rem] leading-[120%] bg-gradient-to-r from-black via-blue-600 to-blue-200 bg-clip-text text-transparent max-md:text-[2rem] max-md:leading-[140%]">
-            {recruitingSection06.headlineLine1} <br />
-            {recruitingSection06.headlineLine2}
+            {section06Texts.headlineLine1} <br />
+            {section06Texts.headlineLine2}
           </h3>
           <p className="text-center text-[#54545C] text-[1.125rem] font-medium leading-[160%] max-md:text-sm w-[100%] max-md:w-[80%]">
-            {recruitingSection06.description}
+            {section06Texts.detail}
           </p>
         </div>
         <Recruitbutton />


### PR DESCRIPTION
## 변경 사항

- `Recruiting-page/config.ts`: FAQ·안내 문구에 쓰이는 날짜 표기를 하드코딩 대신 `recruitingDates` 기반 헬퍼로 동적 생성하도록 변경
  - `recruitingMonthDaySlashFromLabel` (`7월 11일(토)` → `7/11`)
  - `recruitingVacationProjectSeasonWord` (KST 기준 여름/겨울 판별)
  - `recruitingDocumentDueSlashWithWeekday` (`5월 10일(일)` → `5/10(일)`)
- `Section05.tsx`, `Section06.tsx`: 변경된 config 구조 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)